### PR TITLE
Add SeeLevel 709-BTP3/BTP7 tank, temperature, and battery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Devices currently supported :
 | Mopeka         | Mopeka TD200               | https://mopeka.com/commercial-industry-based-solutions/water/#:~:text=Mopeka%20TD40,%20TD200                   |
 | Ruuvi          | Ruuvi Tag                  | https://ruuvi.com/ruuvitag/                                                                                    |
 | Ruuvi          | Ruuvi Air                  | https://ruuvi.com/air/                                                                                         |
-| Garnet         | SeeLevel 709-BTP3          | https://garnetsensors.com/seelevel-ii-709-bt/                                                                  |
-| Garnet         | SeeLevel 709-BTP7          | https://garnetsensors.com/seelevel-ii-709-bt/                                                                  |
+| Garnet         | SeeLevel 709-BTP3          | https://www.garnetinstruments.com/document/709-btp3-seelevel-ii-tank-monitor-2/                                |
+| Garnet         | SeeLevel 709-BTP7          | https://www.garnetinstruments.com/document/709-btp7-seelevel-ii-tank-monitor/                                  |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Devices currently supported :
 | Mopeka         | Mopeka TD200               | https://mopeka.com/commercial-industry-based-solutions/water/#:~:text=Mopeka%20TD40,%20TD200                   |
 | Ruuvi          | Ruuvi Tag                  | https://ruuvi.com/ruuvitag/                                                                                    |
 | Ruuvi          | Ruuvi Air                  | https://ruuvi.com/air/                                                                                         |
+| Garnet         | SeeLevel 709-BTP3          | https://garnetsensors.com/seelevel-ii-709-bt/                                                                  |
+| Garnet         | SeeLevel 709-BTP7          | https://garnetsensors.com/seelevel-ii-709-bt/                                                                  |
 
 ## Installation
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
@@ -21,6 +21,7 @@ class BleDevice(object):
     """
 
     MANUFACTURER_ID = None  # To be overloaded in children classes: int, ble manufacturer id
+    CUSTOM_PARSING = False  # Set True in subclasses that override handle_manufacturer_data() and don't use regs
 
     # Dict of devices classes, key is manufacturer id
     DEVICE_CLASSES = {}
@@ -142,9 +143,10 @@ class BleDevice(object):
             if not isinstance(self.info[dict_key], dict):
                 raise ValueError(f"{self._plog} Configuration '{dict_key}' must be a dict")
 
-        for collection_mandatory in ['roles', 'regs']:
-            if self.info[collection_mandatory].__len__() < 1:
-                raise ValueError(f"{self._plog} Configuration '{collection_mandatory}' must have at least one element")
+        if self.info['roles'].__len__() < 1:
+            raise ValueError(f"{self._plog} Configuration 'roles' must have at least one element")
+        if not self.CUSTOM_PARSING and self.info['regs'].__len__() < 1:
+            raise ValueError(f"{self._plog} Configuration 'regs' must have at least one element")
 
         for role_name in self.info['roles'].keys():
             if role_name not in BleRole.ROLE_CLASSES:
@@ -217,6 +219,58 @@ class BleDevice(object):
             # Creating entries in ble service to enable/disable options
             DbusBleService.get().register_role_service(role_service)
         logging.debug(f"{self._plog} initialized")
+
+    def _create_indexed_role_service(self, role_type: str, index: int, device_name: str = None, config: dict = None):
+        """
+        Create a role service for a specific slot index, producing a unique D-Bus
+        service name like com.victronenergy.tank.{dev_prefix}_{mac}_{index:02d}.
+
+        Use this for devices that expose multiple instances of the same role type
+        (e.g. multi-tank monitors). The service is stored in _role_services keyed
+        by '{role_type}_{index:02d}' and registered with DbusBleService.
+
+        Returns the DbusRoleService, or None on failure.
+        """
+        key = f'{role_type}_{index:02d}'
+        if key in self._role_services:
+            return self._role_services[key]
+
+        role_cls = BleRole.get_class(role_type)
+        if role_cls is None:
+            logging.error(f"{self._plog} unknown role type {role_type!r}")
+            return None
+
+        role = role_cls(config or {})
+        try:
+            role.check_configuration()
+        except ValueError as e:
+            logging.error(f"{self._plog} ignoring {role_type} index {index}: {e}")
+            return None
+
+        base_dev_id = self.info['dev_id']
+        self.info['dev_id'] = f"{base_dev_id}_{index:02d}"
+
+        role_service = DbusRoleService(self, role)
+        role_service.load_settings()
+
+        if device_name:
+            role_service['DeviceName'] = device_name
+
+        self._role_services[key] = role_service
+        DbusBleService.get().register_role_service(role_service)
+
+        self.info['dev_id'] = base_dev_id
+        logging.info(f"{self._plog} created indexed {role_type} service [{index:02d}]")
+        return role_service
+
+    def _is_indexed_role_enabled(self, role_type: str, index: int) -> bool:
+        """Check if a specific indexed role service is enabled in the GUI."""
+        key = f'{role_type}_{index:02d}'
+        role_service = self._role_services.get(key)
+        if role_service is None:
+            return False
+        enabled_path = f"/Devices/{role_service.get_dev_id()}_{role_type}/Enabled"
+        return bool(DbusBleService.get()._get_value(enabled_path))
 
     def _load_str(self, reg: dict, manufacturer_data: bytes) -> str:
         # Check there is enough data

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
@@ -247,19 +247,27 @@ class BleDevice(object):
             logging.error(f"{self._plog} ignoring {role_type} index {index}: {e}")
             return None
 
-        base_dev_id = self.info['dev_id']
-        self.info['dev_id'] = f"{base_dev_id}_{index:02d}"
+        # Pass the indexed dev id explicitly to the role-service
+        # constructor.  ``self.info['dev_id']`` is read once to compute
+        # the override and never mutated; a failure during init
+        # therefore cannot leak partial state into subsequent calls.
+        indexed_dev_id = f"{self.info['dev_id']}_{index:02d}"
+        try:
+            role_service = DbusRoleService(self, role, dev_id=indexed_dev_id)
+            role_service.load_settings()
 
-        role_service = DbusRoleService(self, role)
-        role_service.load_settings()
+            if device_name:
+                role_service['DeviceName'] = device_name
 
-        if device_name:
-            role_service['DeviceName'] = device_name
+            self._role_services[key] = role_service
+            DbusBleService.get().register_role_service(role_service)
+        except Exception:
+            logging.exception(
+                f"{self._plog} failed to create indexed {role_type} "
+                f"service [{index:02d}]"
+            )
+            return None
 
-        self._role_services[key] = role_service
-        DbusBleService.get().register_role_service(role_service)
-
-        self.info['dev_id'] = base_dev_id
         logging.info(f"{self._plog} created indexed {role_type} service [{index:02d}]")
         return role_service
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -25,7 +25,7 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
         3: LPG (tank)            10: Temp 4 (temperature)
         4: LPG 2 (tank)          11: Chemical (tank)
         5: Galley Water (tank)   12: Chemical 2 (tank)
-        6: Galley Water 2 (tank) 13: Battery (unsupported, no role)
+        6: Galley Water 2 (tank) 13: Battery (battery)
 
     Cf.
     - https://github.com/TechBlueprints/victron-seelevel-python
@@ -33,7 +33,7 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
 
     MANUFACTURER_ID = 0x0131  # 305
     PRODUCT_NAME = 'SeeLevel 709-BTP3'
-    ROLES = {'tank': {}, 'temperature': {}}
+    ROLES = {'tank': {}, 'temperature': {}, 'battery': {}}
 
     # (name, role_type, default_fluid_type)
     SENSORS = {
@@ -50,7 +50,7 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
         10: ("Temp 4", "temperature", None),
         11: ("Chemical", "tank", 0),
         12: ("Chemical 2", "tank", 0),
-        13: ("Battery", None, None),
+        13: ("Voltage", "battery", None),
     }
 
     def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
@@ -124,6 +124,14 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
             temp_c = round((sensor_value - 32.0) * 5.0 / 9.0, 1)
             sensor_data = {
                 'Temperature': temp_c,
+                'Status': 0,
+            }
+            self._update_dbus_data(role_service, sensor_data)
+
+        elif role_type == 'battery':
+            voltage = sensor_value / 10.0
+            sensor_data = {
+                '/Dc/0/Voltage': voltage,
                 'Status': 0,
             }
             self._update_dbus_data(role_service, sensor_data)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -33,6 +33,7 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
 
     MANUFACTURER_ID = 0x0131  # 305
     PRODUCT_NAME = 'SeeLevel 709-BTP3'
+    DEV_PREFIX = 'seelevel_btp3'
     ROLES = {'tank': {}, 'temperature': {}, 'battery': {}}
 
     # (name, role_type, default_fluid_type)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -82,7 +82,7 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
         key = f'{role_type}_{sensor_num:02d}'
 
         if key not in self._role_services:
-            config = {}
+            config = {'custom_name': name}
             if role_type == 'tank' and fluid_type is not None:
                 config['fluid_type'] = fluid_type
             role_service = self._create_indexed_role_service(

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -82,7 +82,7 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
         key = f'{role_type}_{sensor_num:02d}'
 
         if key not in self._role_services:
-            config = {'custom_name': name}
+            config = {'custom_name': f"SeeLevel {name}" if role_type == 'battery' else name}
             if role_type == 'tank' and fluid_type is not None:
                 config['fluid_type'] = fluid_type
             role_service = self._create_indexed_role_service(

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -1,9 +1,8 @@
-from ve_types import *
-from ble_device import BleDevice
+from seelevel_common import BleDeviceSeeLevel
 import logging
 
 
-class BleDeviceSeeLevelBTP3(BleDevice):
+class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
     """
     SeeLevel 709-BTP3 (Cypress) tank/temperature/battery monitor.
 
@@ -33,10 +32,10 @@ class BleDeviceSeeLevelBTP3(BleDevice):
     """
 
     MANUFACTURER_ID = 0x0131  # 305
-    CUSTOM_PARSING = True
+    PRODUCT_NAME = 'SeeLevel 709-BTP3'
+    ROLES = {'tank': {}, 'temperature': {}}
 
     # (name, role_type, default_fluid_type)
-    # role_type None = unsupported in this framework
     SENSORS = {
         0:  ("Fresh Water", "tank", 1),
         1:  ("Toilet Water", "tank", 5),
@@ -53,16 +52,6 @@ class BleDeviceSeeLevelBTP3(BleDevice):
         12: ("Chemical 2", "tank", 0),
         13: ("Battery", None, None),
     }
-
-    def configure(self, manufacturer_data: bytes):
-        self.info.update({
-            'product_id': 0xA142,
-            'product_name': 'SeeLevel 709-BTP3',
-            'device_name': 'SeeLevel',
-            'dev_prefix': 'seelevel',
-            'roles': {'tank': {}, 'temperature': {}},
-            'regs': [],
-        })
 
     def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
         if len(manufacturer_data) < 7:
@@ -104,8 +93,7 @@ class BleDeviceSeeLevelBTP3(BleDevice):
         if data_str == "OPN":
             return
         if data_str == "ERR":
-            role_service['Status'] = 5
-            role_service.connect()
+            self._set_error_status(role_service)
             return
 
         try:
@@ -122,15 +110,7 @@ class BleDeviceSeeLevelBTP3(BleDevice):
 
         if role_type == 'tank':
             level = max(0, min(100, sensor_value))
-            capacity = float(role_service['Capacity'] or 0)
-            remaining = round(capacity * level / 100.0, 3) if capacity else 0.0
-
-            sensor_data = {
-                'RawValue': float(level),
-                'Level': level,
-                'Remaining': remaining,
-                'Status': 0,
-            }
+            sensor_data = self._build_tank_sensor_data(level, role_service)
 
             if alarm_state is not None:
                 sensor_data['/Alarms/Low/State'] = int(alarm_state > 0)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -77,15 +77,14 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
         key = f'{role_type}_{sensor_num:02d}'
 
         if key not in self._role_services:
+            config = {}
+            if role_type == 'tank' and fluid_type is not None:
+                config['fluid_type'] = fluid_type
             role_service = self._create_indexed_role_service(
-                role_type, sensor_num, device_name=f"SeeLevel {name}")
+                role_type, sensor_num, device_name=f"SeeLevel {name}",
+                config=config)
             if role_service is None:
                 return
-            if role_type == 'tank':
-                if fluid_type is not None and role_service['FluidType'] == 0:
-                    role_service['FluidType'] = fluid_type
-                if role_service['Capacity'] == 0.2:
-                    role_service['Capacity'] = 0.0
         else:
             role_service = self._role_services[key]
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -1,0 +1,148 @@
+from ve_types import *
+from ble_device import BleDevice
+import logging
+
+
+class BleDeviceSeeLevelBTP3(BleDevice):
+    """
+    SeeLevel 709-BTP3 (Cypress) tank/temperature/battery monitor.
+
+    Each advertisement reports a single sensor. The same BLE MAC sends
+    advertisements for different sensor numbers over time, so services
+    are created lazily as new sensor numbers appear.
+
+    Byte layout (14 bytes):
+        0-2: Coach ID (24-bit, little-endian)
+        3:   Sensor number (0-13)
+        4-6: Sensor data (3 ASCII chars: "OPN", "ERR", or numeric)
+        7-9: Volume in gallons (3 ASCII chars)
+       10-12: Total capacity in gallons (3 ASCII chars)
+        13:  Alarm state (ASCII digit '0'-'9')
+
+    Sensor number mapping:
+        0: Fresh Water (tank)     7: Temp (temperature)
+        1: Toilet Water (tank)    8: Temp 2 (temperature)
+        2: Wash Water (tank)      9: Temp 3 (temperature)
+        3: LPG (tank)            10: Temp 4 (temperature)
+        4: LPG 2 (tank)          11: Chemical (tank)
+        5: Galley Water (tank)   12: Chemical 2 (tank)
+        6: Galley Water 2 (tank) 13: Battery (unsupported, no role)
+
+    Cf.
+    - https://github.com/TechBlueprints/victron-seelevel-python
+    """
+
+    MANUFACTURER_ID = 0x0131  # 305
+    CUSTOM_PARSING = True
+
+    # (name, role_type, default_fluid_type)
+    # role_type None = unsupported in this framework
+    SENSORS = {
+        0:  ("Fresh Water", "tank", 1),
+        1:  ("Toilet Water", "tank", 5),
+        2:  ("Wash Water", "tank", 2),
+        3:  ("LPG", "tank", 8),
+        4:  ("LPG 2", "tank", 8),
+        5:  ("Galley Water", "tank", 2),
+        6:  ("Galley Water 2", "tank", 2),
+        7:  ("Temp", "temperature", None),
+        8:  ("Temp 2", "temperature", None),
+        9:  ("Temp 3", "temperature", None),
+        10: ("Temp 4", "temperature", None),
+        11: ("Chemical", "tank", 0),
+        12: ("Chemical 2", "tank", 0),
+        13: ("Battery", None, None),
+    }
+
+    def configure(self, manufacturer_data: bytes):
+        self.info.update({
+            'product_id': 0xA142,
+            'product_name': 'SeeLevel 709-BTP3',
+            'device_name': 'SeeLevel',
+            'dev_prefix': 'seelevel',
+            'roles': {'tank': {}, 'temperature': {}},
+            'regs': [],
+        })
+
+    def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
+        if len(manufacturer_data) < 7:
+            return False
+        sensor_num = manufacturer_data[3]
+        return sensor_num in self.SENSORS
+
+    def init(self):
+        self._load_configuration()
+        logging.debug(f"{self._plog} initialized (services created on demand)")
+
+    def handle_manufacturer_data(self, manufacturer_data: bytes):
+        sensor_num = manufacturer_data[3]
+        sensor_info = self.SENSORS.get(sensor_num)
+        if sensor_info is None:
+            return
+
+        name, role_type, fluid_type = sensor_info
+        if role_type is None:
+            return
+
+        key = f'{role_type}_{sensor_num:02d}'
+
+        if key not in self._role_services:
+            role_service = self._create_indexed_role_service(
+                role_type, sensor_num, device_name=f"SeeLevel {name}")
+            if role_service is None:
+                return
+            if role_type == 'tank' and fluid_type is not None and role_service['FluidType'] == 0:
+                role_service['FluidType'] = fluid_type
+        else:
+            role_service = self._role_services[key]
+
+        if not self._is_indexed_role_enabled(role_type, sensor_num):
+            return
+
+        data_str = manufacturer_data[4:7].decode('ascii', errors='ignore').strip()
+
+        if data_str == "OPN":
+            return
+        if data_str == "ERR":
+            role_service['Status'] = 5
+            role_service.connect()
+            return
+
+        try:
+            sensor_value = int(data_str)
+        except ValueError:
+            logging.warning(f"{self._plog} sensor {sensor_num}: unparseable value {data_str!r}")
+            return
+
+        alarm_state = None
+        if len(manufacturer_data) >= 14:
+            alarm_byte = manufacturer_data[13]
+            if ord('0') <= alarm_byte <= ord('9'):
+                alarm_state = alarm_byte - ord('0')
+
+        if role_type == 'tank':
+            level = max(0, min(100, sensor_value))
+            capacity = float(role_service['Capacity'] or 0)
+            remaining = round(capacity * level / 100.0, 3) if capacity else 0.0
+
+            sensor_data = {
+                'RawValue': float(level),
+                'Level': level,
+                'Remaining': remaining,
+                'Status': 0,
+            }
+
+            if alarm_state is not None:
+                sensor_data['/Alarms/Low/State'] = int(alarm_state > 0)
+
+            self._update_dbus_data(role_service, sensor_data)
+
+        elif role_type == 'temperature':
+            temp_c = round((sensor_value - 32.0) * 5.0 / 9.0, 1)
+            sensor_data = {
+                'Temperature': temp_c,
+                'Status': 0,
+            }
+            self._update_dbus_data(role_service, sensor_data)
+
+        role_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -105,20 +105,19 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
             logging.warning(f"{self._plog} sensor {sensor_num}: unparseable value {data_str!r}")
             return
 
-        alarm_state = None
         if len(manufacturer_data) >= 14:
             alarm_byte = manufacturer_data[13]
             if ord('0') <= alarm_byte <= ord('9'):
-                alarm_state = alarm_byte - ord('0')
+                hw_alarm = alarm_byte - ord('0')
+                if hw_alarm > 0:
+                    logging.debug(f"{self._plog} sensor {sensor_num}: hardware alarm {hw_alarm}")
 
         if role_type == 'tank':
             level = max(0, min(100, sensor_value))
             sensor_data = self._build_tank_sensor_data(level, role_service)
-
-            if alarm_state is not None:
-                sensor_data['/Alarms/Low/State'] = int(alarm_state > 0)
-
             self._update_dbus_data(role_service, sensor_data)
+            for alarm in role_service.ble_role.info.get('alarms', []):
+                role_service.update_alarm(alarm)
 
         elif role_type == 'temperature':
             temp_c = round((sensor_value - 32.0) * 5.0 / 9.0, 1)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -126,6 +126,7 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
                 'Temperature': temp_c,
                 'Status': 0,
             }
+            role_service.ble_role.update_data(role_service, sensor_data)
             self._update_dbus_data(role_service, sensor_data)
 
         elif role_type == 'battery':

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -80,8 +80,11 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
                 role_type, sensor_num, device_name=f"SeeLevel {name}")
             if role_service is None:
                 return
-            if role_type == 'tank' and fluid_type is not None and role_service['FluidType'] == 0:
-                role_service['FluidType'] = fluid_type
+            if role_type == 'tank':
+                if fluid_type is not None and role_service['FluidType'] == 0:
+                    role_service['FluidType'] = fluid_type
+                if role_service['Capacity'] == 0.2:
+                    role_service['Capacity'] = 0.0
         else:
             role_service = self._role_services[key]
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -1,0 +1,139 @@
+from seelevel_common import BleDeviceSeeLevel
+import logging
+
+
+class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
+    """
+    SeeLevel 709-BTP3 (Cypress) tank/temperature/battery monitor.
+
+    Each advertisement reports a single sensor. The same BLE MAC sends
+    advertisements for different sensor numbers over time, so services
+    are created lazily as new sensor numbers appear.
+
+    Byte layout (14 bytes):
+        0-2: Coach ID (24-bit, little-endian)
+        3:   Sensor number (0-13)
+        4-6: Sensor data (3 ASCII chars: "OPN", "ERR", or numeric)
+        7-9: Volume in gallons (3 ASCII chars)
+       10-12: Total capacity in gallons (3 ASCII chars)
+        13:  Alarm state (ASCII digit '0'-'9')
+
+    Sensor number mapping:
+        0: Fresh Water (tank)     7: Temp (temperature)
+        1: Toilet Water (tank)    8: Temp 2 (temperature)
+        2: Wash Water (tank)      9: Temp 3 (temperature)
+        3: LPG (tank)            10: Temp 4 (temperature)
+        4: LPG 2 (tank)          11: Chemical (tank)
+        5: Galley Water (tank)   12: Chemical 2 (tank)
+        6: Galley Water 2 (tank) 13: Battery (battery)
+
+    Cf.
+    - https://github.com/TechBlueprints/victron-seelevel-python
+    """
+
+    MANUFACTURER_ID = 0x0131  # 305
+    PRODUCT_NAME = 'SeeLevel 709-BTP3'
+    ROLES = {'tank': {}, 'temperature': {}, 'battery': {}}
+
+    # (name, role_type, default_fluid_type)
+    SENSORS = {
+        0:  ("Fresh Water", "tank", 1),
+        1:  ("Toilet Water", "tank", 5),
+        2:  ("Wash Water", "tank", 2),
+        3:  ("LPG", "tank", 8),
+        4:  ("LPG 2", "tank", 8),
+        5:  ("Galley Water", "tank", 2),
+        6:  ("Galley Water 2", "tank", 2),
+        7:  ("Temp", "temperature", None),
+        8:  ("Temp 2", "temperature", None),
+        9:  ("Temp 3", "temperature", None),
+        10: ("Temp 4", "temperature", None),
+        11: ("Chemical", "tank", 0),
+        12: ("Chemical 2", "tank", 0),
+        13: ("Voltage", "battery", None),
+    }
+
+    def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
+        if len(manufacturer_data) < 7:
+            return False
+        sensor_num = manufacturer_data[3]
+        return sensor_num in self.SENSORS
+
+    def init(self):
+        self._load_configuration()
+        logging.debug(f"{self._plog} initialized (services created on demand)")
+
+    def handle_manufacturer_data(self, manufacturer_data: bytes):
+        sensor_num = manufacturer_data[3]
+        sensor_info = self.SENSORS.get(sensor_num)
+        if sensor_info is None:
+            return
+
+        name, role_type, fluid_type = sensor_info
+        if role_type is None:
+            return
+
+        key = f'{role_type}_{sensor_num:02d}'
+
+        if key not in self._role_services:
+            role_service = self._create_indexed_role_service(
+                role_type, sensor_num, device_name=f"SeeLevel {name}")
+            if role_service is None:
+                return
+            if role_type == 'tank':
+                if fluid_type is not None and role_service['FluidType'] == 0:
+                    role_service['FluidType'] = fluid_type
+                if role_service['Capacity'] == 0.2:
+                    role_service['Capacity'] = 0.0
+        else:
+            role_service = self._role_services[key]
+
+        if not self._is_indexed_role_enabled(role_type, sensor_num):
+            return
+
+        data_str = manufacturer_data[4:7].decode('ascii', errors='ignore').strip()
+
+        if data_str == "OPN":
+            return
+        if data_str == "ERR":
+            self._set_error_status(role_service)
+            return
+
+        try:
+            sensor_value = int(data_str)
+        except ValueError:
+            logging.warning(f"{self._plog} sensor {sensor_num}: unparseable value {data_str!r}")
+            return
+
+        alarm_state = None
+        if len(manufacturer_data) >= 14:
+            alarm_byte = manufacturer_data[13]
+            if ord('0') <= alarm_byte <= ord('9'):
+                alarm_state = alarm_byte - ord('0')
+
+        if role_type == 'tank':
+            level = max(0, min(100, sensor_value))
+            sensor_data = self._build_tank_sensor_data(level, role_service)
+
+            if alarm_state is not None:
+                sensor_data['/Alarms/Low/State'] = int(alarm_state > 0)
+
+            self._update_dbus_data(role_service, sensor_data)
+
+        elif role_type == 'temperature':
+            temp_c = round((sensor_value - 32.0) * 5.0 / 9.0, 1)
+            sensor_data = {
+                'Temperature': temp_c,
+                'Status': 0,
+            }
+            self._update_dbus_data(role_service, sensor_data)
+
+        elif role_type == 'battery':
+            voltage = sensor_value / 10.0
+            sensor_data = {
+                '/Dc/0/Voltage': voltage,
+                'Status': 0,
+            }
+            self._update_dbus_data(role_service, sensor_data)
+
+        role_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -74,6 +74,11 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
         if role_type is None:
             return
 
+        data_str = manufacturer_data[4:7].decode('ascii', errors='ignore').strip()
+
+        if data_str == "OPN":
+            return
+
         key = f'{role_type}_{sensor_num:02d}'
 
         if key not in self._role_services:
@@ -91,10 +96,6 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
         if not self._is_indexed_role_enabled(role_type, sensor_num):
             return
 
-        data_str = manufacturer_data[4:7].decode('ascii', errors='ignore').strip()
-
-        if data_str == "OPN":
-            return
         if data_str == "ERR":
             self._set_error_status(role_service)
             return

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -21,6 +21,7 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
 
     MANUFACTURER_ID = 0x0CC0  # 3264
     PRODUCT_NAME = 'SeeLevel 709-BTP7'
+    DEV_PREFIX = 'seelevel_btp7'
     ROLES = {'tank': {}, 'battery': {}}
 
     TANK_SLOTS = [

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -1,9 +1,8 @@
-from ve_types import *
-from ble_device import BleDevice
+from seelevel_common import BleDeviceSeeLevel
 import logging
 
 
-class BleDeviceSeeLevelBTP7(BleDevice):
+class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
     """
     SeeLevel 709-BTP7 tank monitor.
 
@@ -21,7 +20,8 @@ class BleDeviceSeeLevelBTP7(BleDevice):
     """
 
     MANUFACTURER_ID = 0x0CC0  # 3264
-    CUSTOM_PARSING = True
+    PRODUCT_NAME = 'SeeLevel 709-BTP7'
+    ROLES = {'tank': {}}
 
     TANK_SLOTS = [
         ("Fresh Water", 1),      # slot 0: FluidType = Fresh water
@@ -33,28 +33,6 @@ class BleDeviceSeeLevelBTP7(BleDevice):
         ("Wash Water 3", 2),     # slot 6
         ("LPG", 8),             # slot 7: FluidType = LPG
     ]
-
-    STATUS_CODES = {
-        101: "Short Circuit",
-        102: "Open",
-        103: "Bitcount error",
-        104: "Non-stacked config with stacked data",
-        105: "Stacked, missing bottom sender",
-        106: "Stacked, missing top sender",
-        108: "Bad Checksum",
-        110: "Tank disabled",
-        111: "Tank init",
-    }
-
-    def configure(self, manufacturer_data: bytes):
-        self.info.update({
-            'product_id': 0xA142,
-            'product_name': 'SeeLevel 709-BTP7',
-            'device_name': 'SeeLevel',
-            'dev_prefix': 'seelevel',
-            'roles': {'tank': {}},
-            'regs': [],
-        })
 
     def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
         return len(manufacturer_data) >= 12
@@ -82,21 +60,9 @@ class BleDeviceSeeLevelBTP7(BleDevice):
             level = manufacturer_data[slot + 3]
 
             if level > 100:
-                status_msg = self.STATUS_CODES.get(level, f"Unknown ({level})")
-                logging.debug(f"{self._plog} slot {slot}: error {status_msg}")
-                role_service['Status'] = 5
-                role_service.connect()
+                self._set_error_status(role_service, level)
                 continue
 
-            capacity = float(role_service['Capacity'] or 0)
-            remaining = round(capacity * level / 100.0, 3) if capacity else 0.0
-
-            sensor_data = {
-                'RawValue': float(level),
-                'Level': level,
-                'Remaining': remaining,
-                'Status': 0,
-            }
-
+            sensor_data = self._build_tank_sensor_data(level, role_service)
             self._update_dbus_data(role_service, sensor_data)
             role_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -26,8 +26,8 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
 
     TANK_SLOTS = [
         ("Fresh Water", 1),      # slot 0: FluidType = Fresh water
-        ("Wash Water", 2),       # slot 1: FluidType = Waste water
-        ("Toilet Water", 5),     # slot 2: FluidType = Black water
+        ("Wash Water", 2),       # slot 1: FluidType = Wash water
+        ("Toilet Water", 5),     # slot 2: FluidType = Toilet water
         ("Fresh Water 2", 1),    # slot 3
         ("Wash Water 2", 2),     # slot 4
         ("Toilet Water 2", 5),   # slot 5

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -44,10 +44,11 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
         for slot, (tank_name, fluid_type) in enumerate(self.TANK_SLOTS):
             role_service = self._create_indexed_role_service(
                 'tank', slot, device_name=f"SeeLevel {tank_name}",
-                config={'fluid_type': fluid_type})
+                config={'fluid_type': fluid_type, 'custom_name': tank_name})
 
         self._create_indexed_role_service(
-            'battery', 8, device_name="SeeLevel Voltage")
+            'battery', 8, device_name="SeeLevel Voltage",
+            config={'custom_name': 'Voltage'})
 
         logging.debug(f"{self._plog} initialized {len(self._role_services)} service slots")
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -43,12 +43,8 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
 
         for slot, (tank_name, fluid_type) in enumerate(self.TANK_SLOTS):
             role_service = self._create_indexed_role_service(
-                'tank', slot, device_name=f"SeeLevel {tank_name}")
-            if role_service:
-                if role_service['FluidType'] == 0:
-                    role_service['FluidType'] = fluid_type
-                if role_service['Capacity'] == 0.2:
-                    role_service['Capacity'] = 0.0
+                'tank', slot, device_name=f"SeeLevel {tank_name}",
+                config={'fluid_type': fluid_type})
 
         self._create_indexed_role_service(
             'battery', 8, device_name="SeeLevel Voltage")

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -48,7 +48,7 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
 
         self._create_indexed_role_service(
             'battery', 8, device_name="SeeLevel Voltage",
-            config={'custom_name': 'Voltage'})
+            config={'custom_name': 'SeeLevel Voltage'})
 
         logging.debug(f"{self._plog} initialized {len(self._role_services)} service slots")
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -1,0 +1,102 @@
+from ve_types import *
+from ble_device import BleDevice
+import logging
+
+
+class BleDeviceSeeLevelBTP7(BleDevice):
+    """
+    SeeLevel 709-BTP7 tank monitor.
+
+    Broadcasts 8 tank levels (0-100%) and battery voltage in a single
+    14-byte manufacturer data advertisement.
+
+    Byte layout:
+        0-2: Coach ID (24-bit, little-endian)
+        3-10: Tank levels (1 byte each, 0-100 = %, >100 = error code)
+              Slots: Fresh, Wash, Toilet, Fresh2, Wash2, Toilet2, Wash3, LPG
+        11:  Battery voltage * 100
+
+    Cf.
+    - https://github.com/TechBlueprints/victron-seelevel-python
+    """
+
+    MANUFACTURER_ID = 0x0CC0  # 3264
+    CUSTOM_PARSING = True
+
+    TANK_SLOTS = [
+        ("Fresh Water", 1),      # slot 0: FluidType = Fresh water
+        ("Wash Water", 2),       # slot 1: FluidType = Waste water
+        ("Toilet Water", 5),     # slot 2: FluidType = Black water
+        ("Fresh Water 2", 1),    # slot 3
+        ("Wash Water 2", 2),     # slot 4
+        ("Toilet Water 2", 5),   # slot 5
+        ("Wash Water 3", 2),     # slot 6
+        ("LPG", 8),             # slot 7: FluidType = LPG
+    ]
+
+    STATUS_CODES = {
+        101: "Short Circuit",
+        102: "Open",
+        103: "Bitcount error",
+        104: "Non-stacked config with stacked data",
+        105: "Stacked, missing bottom sender",
+        106: "Stacked, missing top sender",
+        108: "Bad Checksum",
+        110: "Tank disabled",
+        111: "Tank init",
+    }
+
+    def configure(self, manufacturer_data: bytes):
+        self.info.update({
+            'product_id': 0xA142,
+            'product_name': 'SeeLevel 709-BTP7',
+            'device_name': 'SeeLevel',
+            'dev_prefix': 'seelevel',
+            'roles': {'tank': {}},
+            'regs': [],
+        })
+
+    def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
+        return len(manufacturer_data) >= 12
+
+    def init(self):
+        self._load_configuration()
+
+        for slot, (tank_name, fluid_type) in enumerate(self.TANK_SLOTS):
+            role_service = self._create_indexed_role_service(
+                'tank', slot, device_name=f"SeeLevel {tank_name}")
+            if role_service and role_service['FluidType'] == 0:
+                role_service['FluidType'] = fluid_type
+
+        logging.debug(f"{self._plog} initialized {len(self._role_services)} tank slots")
+
+    def handle_manufacturer_data(self, manufacturer_data: bytes):
+        for slot in range(8):
+            if not self._is_indexed_role_enabled('tank', slot):
+                continue
+
+            role_service = self._role_services.get(f'tank_{slot:02d}')
+            if role_service is None:
+                continue
+
+            level = manufacturer_data[slot + 3]
+
+            if level > 100:
+                status_msg = self.STATUS_CODES.get(level, f"Unknown ({level})")
+                logging.debug(f"{self._plog} slot {slot}: error {status_msg}")
+                role_service['Status'] = 5
+                role_service.connect()
+                continue
+
+            capacity = float(role_service['Capacity'] or 0)
+            remaining = round(capacity * level / 100.0, 3) if capacity else 0.0
+
+            sensor_data = {
+                'RawValue': float(level),
+                'Level': level,
+                'Remaining': remaining,
+                'Status': 0,
+            }
+
+            self._update_dbus_data(role_service, sensor_data)
+            role_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -4,7 +4,7 @@ import logging
 
 class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
     """
-    SeeLevel 709-BTP7 tank monitor.
+    SeeLevel 709-BTP7 tank/battery monitor.
 
     Broadcasts 8 tank levels (0-100%) and battery voltage in a single
     14-byte manufacturer data advertisement.
@@ -13,7 +13,7 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
         0-2: Coach ID (24-bit, little-endian)
         3-10: Tank levels (1 byte each, 0-100 = %, >100 = error code)
               Slots: Fresh, Wash, Toilet, Fresh2, Wash2, Toilet2, Wash3, LPG
-        11:  Battery voltage * 100
+        11:  Battery voltage * 10 (e.g. 120 = 12.0V)
 
     Cf.
     - https://github.com/TechBlueprints/victron-seelevel-python
@@ -21,7 +21,7 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
 
     MANUFACTURER_ID = 0x0CC0  # 3264
     PRODUCT_NAME = 'SeeLevel 709-BTP7'
-    ROLES = {'tank': {}}
+    ROLES = {'tank': {}, 'battery': {}}
 
     TANK_SLOTS = [
         ("Fresh Water", 1),      # slot 0: FluidType = Fresh water
@@ -49,7 +49,10 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
                 if role_service['Capacity'] == 0.2:
                     role_service['Capacity'] = 0.0
 
-        logging.debug(f"{self._plog} initialized {len(self._role_services)} tank slots")
+        self._create_indexed_role_service(
+            'battery', 8, device_name="SeeLevel Voltage")
+
+        logging.debug(f"{self._plog} initialized {len(self._role_services)} service slots")
 
     def handle_manufacturer_data(self, manufacturer_data: bytes):
         for slot in range(8):
@@ -69,3 +72,13 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
             sensor_data = self._build_tank_sensor_data(level, role_service)
             self._update_dbus_data(role_service, sensor_data)
             role_service.connect()
+
+        if self._is_indexed_role_enabled('battery', 8):
+            battery_service = self._role_services.get('battery_08')
+            if battery_service and len(manufacturer_data) >= 12:
+                voltage = manufacturer_data[11] / 10.0
+                self._update_dbus_data(battery_service, {
+                    '/Dc/0/Voltage': voltage,
+                    'Status': 0,
+                })
+                battery_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -43,8 +43,11 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
         for slot, (tank_name, fluid_type) in enumerate(self.TANK_SLOTS):
             role_service = self._create_indexed_role_service(
                 'tank', slot, device_name=f"SeeLevel {tank_name}")
-            if role_service and role_service['FluidType'] == 0:
-                role_service['FluidType'] = fluid_type
+            if role_service:
+                if role_service['FluidType'] == 0:
+                    role_service['FluidType'] = fluid_type
+                if role_service['Capacity'] == 0.2:
+                    role_service['Capacity'] = 0.0
 
         logging.debug(f"{self._plog} initialized {len(self._role_services)} tank slots")
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -71,6 +71,8 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
 
             sensor_data = self._build_tank_sensor_data(level, role_service)
             self._update_dbus_data(role_service, sensor_data)
+            for alarm in role_service.ble_role.info.get('alarms', []):
+                role_service.update_alarm(alarm)
             role_service.connect()
 
         if self._is_indexed_role_enabled('battery', 8):

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -1,0 +1,84 @@
+from seelevel_common import BleDeviceSeeLevel
+import logging
+
+
+class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
+    """
+    SeeLevel 709-BTP7 tank/battery monitor.
+
+    Broadcasts 8 tank levels (0-100%) and battery voltage in a single
+    14-byte manufacturer data advertisement.
+
+    Byte layout:
+        0-2: Coach ID (24-bit, little-endian)
+        3-10: Tank levels (1 byte each, 0-100 = %, >100 = error code)
+              Slots: Fresh, Wash, Toilet, Fresh2, Wash2, Toilet2, Wash3, LPG
+        11:  Battery voltage * 10 (e.g. 120 = 12.0V)
+
+    Cf.
+    - https://github.com/TechBlueprints/victron-seelevel-python
+    """
+
+    MANUFACTURER_ID = 0x0CC0  # 3264
+    PRODUCT_NAME = 'SeeLevel 709-BTP7'
+    ROLES = {'tank': {}, 'battery': {}}
+
+    TANK_SLOTS = [
+        ("Fresh Water", 1),      # slot 0: FluidType = Fresh water
+        ("Wash Water", 2),       # slot 1: FluidType = Waste water
+        ("Toilet Water", 5),     # slot 2: FluidType = Black water
+        ("Fresh Water 2", 1),    # slot 3
+        ("Wash Water 2", 2),     # slot 4
+        ("Toilet Water 2", 5),   # slot 5
+        ("Wash Water 3", 2),     # slot 6
+        ("LPG", 8),             # slot 7: FluidType = LPG
+    ]
+
+    def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
+        return len(manufacturer_data) >= 12
+
+    def init(self):
+        self._load_configuration()
+
+        for slot, (tank_name, fluid_type) in enumerate(self.TANK_SLOTS):
+            role_service = self._create_indexed_role_service(
+                'tank', slot, device_name=f"SeeLevel {tank_name}")
+            if role_service:
+                if role_service['FluidType'] == 0:
+                    role_service['FluidType'] = fluid_type
+                if role_service['Capacity'] == 0.2:
+                    role_service['Capacity'] = 0.0
+
+        self._create_indexed_role_service(
+            'battery', 8, device_name="SeeLevel Voltage")
+
+        logging.debug(f"{self._plog} initialized {len(self._role_services)} service slots")
+
+    def handle_manufacturer_data(self, manufacturer_data: bytes):
+        for slot in range(8):
+            if not self._is_indexed_role_enabled('tank', slot):
+                continue
+
+            role_service = self._role_services.get(f'tank_{slot:02d}')
+            if role_service is None:
+                continue
+
+            level = manufacturer_data[slot + 3]
+
+            if level > 100:
+                self._set_error_status(role_service, level)
+                continue
+
+            sensor_data = self._build_tank_sensor_data(level, role_service)
+            self._update_dbus_data(role_service, sensor_data)
+            role_service.connect()
+
+        if self._is_indexed_role_enabled('battery', 8):
+            battery_service = self._role_services.get('battery_08')
+            if battery_service and len(manufacturer_data) >= 12:
+                voltage = manufacturer_data[11] / 10.0
+                self._update_dbus_data(battery_service, {
+                    '/Dc/0/Voltage': voltage,
+                    'Status': 0,
+                })
+                battery_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role.py
@@ -20,6 +20,7 @@ class BleRole(object):
             'settings': [],     # Optional, list of dict, settings that could be set through UI
             'alarms': [],       # Optional, list of dict, raisable alarms
         }
+        self._custom_name_default = config.get('custom_name', '') if config else ''
 
     def init(self, role_service):
         """

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_battery.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_battery.py
@@ -1,0 +1,21 @@
+from ble_role import BleRole
+
+
+class BleRoleBattery(BleRole):
+    """
+    Battery voltage monitor role class.
+    Device claiming this role must provide a '/Dc/0/Voltage' item.
+    """
+
+    NAME = 'battery'
+
+    def __init__(self, config: dict = None):
+        super().__init__()
+
+        self.info.update(
+            {
+                'name': 'battery',
+                'dev_instance': 50,
+                'settings': [],
+            },
+        )

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_battery.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_battery.py
@@ -10,7 +10,7 @@ class BleRoleBattery(BleRole):
     NAME = 'battery'
 
     def __init__(self, config: dict = None):
-        super().__init__()
+        super().__init__(config)
 
         self.info.update(
             {

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_digitalinput.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_digitalinput.py
@@ -55,7 +55,7 @@ class BleRoleDigitalInput(BleRole):
     }
 
     def __init__(self, config: dict = None):
-        super().__init__()
+        super().__init__(config)
         self._input_state: int = 0
 
         self.info.update(

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_meteo.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_meteo.py
@@ -17,7 +17,7 @@ class BleRoleMeteo(BleRole):
     NAME = 'meteo'
 
     def __init__(self, config: dict = None):
-        super().__init__()
+        super().__init__(config)
 
         self.info.update(
             {

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_movement.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_movement.py
@@ -16,7 +16,7 @@ class BleRoleMovement(BleRole):
     NAME = 'movement'
 
     def __init__(self, config: dict = None):
-        super().__init__()
+        super().__init__(config)
         self._count = None
 
         self.info.update(

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
@@ -60,7 +60,7 @@ class BleRoleTank(BleRole):
     }
 
     def __init__(self, config: dict = None):
-        super().__init__()
+        super().__init__(config)
 
         flags = config.get('flags', []) if config is not None else []
         self._is_topdown: bool = 'TANK_FLAG_TOPDOWN' in flags

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
@@ -66,6 +66,8 @@ class BleRoleTank(BleRole):
         self._is_topdown: bool = 'TANK_FLAG_TOPDOWN' in flags
         self._shape_map = None
 
+        fluid_type_default = config.get('fluid_type', 0) if config else 0
+
         self.info.update(
             {
                 'name': 'tank',
@@ -85,7 +87,7 @@ class BleRoleTank(BleRole):
                         'name': 'FluidType',
                         'props': {
                             'type': VE_SN32,
-                            'def': 0,
+                            'def': fluid_type_default,
                             'min': 0,
                             'max': self.INT32_MAX - 3
                         }
@@ -240,8 +242,11 @@ class BleRoleTank(BleRole):
         return int(100 * level), level * capacity, 0
 
     def _tank_capacity_changed(self, role_service, new_capacity):
+        raw = role_service['RawValue']
+        if raw is None:
+            return
         (level, remain, status) = self._compute_level(
-            float(role_service['RawValue']),
+            float(raw),
             float(role_service['RawValueEmpty']),
             float(role_service['RawValueFull']),
             float(new_capacity)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
@@ -24,10 +24,10 @@ class BleRoleTank(BleRole):
     FLUID_TYPES = {
         0: 'Fuel',
         1: 'Fresh water',
-        2: 'Waste water',
+        2: 'Wash water',
         3: 'Live well',
         4: 'Oil',
-        5: 'Black water (sewage)',
+        5: 'Toilet water',
         6: 'Gasoline',
         7: 'Diesel',
         8: 'LPG',

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
@@ -228,7 +228,7 @@ class BleRoleTank(BleRole):
         elif level > 1:
             level = 1
 
-        for i in range(1, len(self._shape_map)):
+        for i in range(1, len(self._shape_map) if self._shape_map else 0):
             if self._shape_map[i][0] >= level:
                 lev_1 = float(self._shape_map[i-1][0])
                 lev_2 = float(self._shape_map[i][0])

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
@@ -1,6 +1,7 @@
 from ble_role import BleRole
 from ve_types import *
 import logging
+import time
 
 
 class BleRoleTank(BleRole):
@@ -65,6 +66,7 @@ class BleRoleTank(BleRole):
         flags = config.get('flags', []) if config is not None else []
         self._is_topdown: bool = 'TANK_FLAG_TOPDOWN' in flags
         self._shape_map = None
+        self._alarm_pending: dict[str, float | None] = {}
 
         self.info.update(
             {
@@ -136,6 +138,15 @@ class BleRoleTank(BleRole):
                         }
                     },
                     {
+                        'name': '/Alarms/High/Delay',
+                        'props': {
+                            'type': VE_SN32,
+                            'def': 5,
+                            'min': 0,
+                            'max': 100
+                        }
+                    },
+                    {
                         'name': '/Alarms/Low/Enable',
                         'props': {
                             'type': VE_UN8,
@@ -162,6 +173,15 @@ class BleRoleTank(BleRole):
                             'max': 100
                         }
                     },
+                    {
+                        'name': '/Alarms/Low/Delay',
+                        'props': {
+                            'type': VE_SN32,
+                            'def': 30,
+                            'min': 0,
+                            'max': 100
+                        }
+                    },
                 ],
                 'alarms': [
                     {
@@ -176,6 +196,29 @@ class BleRoleTank(BleRole):
             }
         )
 
+    def _check_alarm_delay(self, key: str, triggered: bool, delay: int) -> bool:
+        """
+        Apply alarm delay logic. Returns True when the alarm should be active.
+
+        When `triggered` is True (level past threshold) and `delay` > 0, the
+        alarm only activates after the level has been past the threshold for
+        `delay` continuous seconds.  If the level recovers before the delay
+        expires, the pending timer is cleared.
+        """
+        now = time.monotonic()
+        if triggered:
+            if delay <= 0:
+                self._alarm_pending.pop(key, None)
+                return True
+            pending_since = self._alarm_pending.get(key)
+            if pending_since is None:
+                self._alarm_pending[key] = now
+                return False
+            return (now - pending_since) >= delay
+        else:
+            self._alarm_pending.pop(key, None)
+            return False
+
     def get_alarm_high_state(self, role_service) -> int:
         """
         Default method to compute tank high level alarm. Can be overridden by overloading info['alarms'] entries in device class.
@@ -185,7 +228,12 @@ class BleRoleTank(BleRole):
             alarm_state = bool(role_service['/Alarms/High/State'])
             alarm_threshold = role_service[f"/Alarms/High/{'Restore' if alarm_state else 'Active'}"]
             tank_level = float(role_service['Level'])
-            return int(tank_level > alarm_threshold)
+            triggered = tank_level > alarm_threshold
+            if alarm_state:
+                return int(triggered)
+            delay = int(role_service['/Alarms/High/Delay'] or 0)
+            svc_id = id(role_service)
+            return int(self._check_alarm_delay(f'high_{svc_id}', triggered, delay))
         else:
             return 0
 
@@ -198,7 +246,12 @@ class BleRoleTank(BleRole):
             alarm_state = bool(role_service['/Alarms/Low/State'])
             alarm_threshold = role_service[f"/Alarms/Low/{'Restore' if alarm_state else 'Active'}"]
             tank_level = float(role_service['Level'])
-            return int(tank_level < alarm_threshold)
+            triggered = tank_level < alarm_threshold
+            if alarm_state:
+                return int(triggered)
+            delay = int(role_service['/Alarms/Low/Delay'] or 0)
+            svc_id = id(role_service)
+            return int(self._check_alarm_delay(f'low_{svc_id}', triggered, delay))
         else:
             return 0
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_temperature.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_temperature.py
@@ -22,7 +22,7 @@ class BleRoleTemperature(BleRole):
     }
 
     def __init__(self, config: dict = None):
-        super().__init__()
+        super().__init__(config)
 
         self.info.update(
             {

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
@@ -201,10 +201,11 @@ class DbusRoleService(object):
         return self._dbus_id
 
     def _init_custom_name(self):
+        default_name = getattr(self.ble_role, '_custom_name_default', '')
         self._set_proxy_setting(
             f"/Settings/Devices/{self._dbus_id}/CustomName",
             '/CustomName',
-            '',
+            default_name,
         )
 
     def get_custom_name(self) -> str:

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
@@ -220,8 +220,8 @@ class DbusRoleService(object):
             f"/Settings/Devices/{self._dbus_id}{name}",
             name,
             props['def'],
-            props['min'],
-            props['max'],
+            props.get('min', 0),
+            props.get('max', 0),
             callback=callback
         )
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
@@ -13,7 +13,19 @@ class DbusRoleService(object):
     Role service class. Responsible for holding and sharing data through a dedicated dbus service.
     """
 
-    def __init__(self, ble_device, ble_role: BleRole):
+    def __init__(self, ble_device, ble_role: BleRole, dev_id: str = None):
+        """Construct a role service for *ble_device* fulfilling *ble_role*.
+
+        *dev_id* — explicit override of the device id used for the bus
+        name and settings paths.  Multi-sensor devices (e.g. SeeLevel)
+        register one role service per sensor channel and need names like
+        ``com.victronenergy.tank.<dev_prefix>_<mac>_<index:02d>``; they
+        pass the indexed value here.  When omitted, falls back to the
+        canonical ``ble_device.info['dev_id']`` set during the device's
+        configure pass.  This parameter exists so callers do not need
+        to mutate ``ble_device.info`` to inject a different dev id —
+        mutation through shared state has bitten us before.
+        """
         # private=True to allow creation of multiple services in the same app
         self._bus: dbus.Bus = dbus.SessionBus(
             private=True) if 'DBUS_SESSION_BUS_ADDRESS' in os.environ else dbus.SystemBus(private=True)
@@ -25,7 +37,7 @@ class DbusRoleService(object):
         self._dbus_iface = dbus.Interface(
             self._bus.get_object('org.freedesktop.DBus', '/org/freedesktop/DBus'),
             'org.freedesktop.DBus')
-        self._dev_id = self._ble_device.info['dev_id']
+        self._dev_id = dev_id if dev_id is not None else self._ble_device.info['dev_id']
         self._dbus_id = f"{self._dev_id}/{self.ble_role.NAME}"
         self._init_dbus_service()
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
@@ -1,3 +1,112 @@
+"""
+SeeLevel 709-BT Protocol Reference
+====================================
+
+The Garnet SeeLevel 709-BT is a BLE Broadcaster that continuously cycles
+through its connected sensors, transmitting advertisement packets.  No BLE
+connection is required -- all data is read from manufacturer-specific data
+in the advertisement PDU.
+
+Two hardware variants exist, distinguished by manufacturer ID:
+
+  BTP3 (Cypress)   MFG ID 305  (0x0131)
+  BTP7 (SeeLevel)  MFG ID 3264 (0x0CC0)
+
+
+BLE Packet Formats
+------------------
+
+BTP3 payload (14 bytes):
+    Bytes 0-2   Coach ID (24-bit, little-endian)
+    Byte  3     Sensor number (0-13)
+    Bytes 4-6   Sensor data (3 ASCII chars: "OPN", "ERR", or numeric)
+    Bytes 7-9   Volume in gallons (3 ASCII chars)
+    Bytes 10-12 Total capacity in gallons (3 ASCII chars)
+    Byte  13    Alarm state (ASCII digit '0'-'9')
+
+BTP7 payload (14 bytes):
+    Bytes 0-2   Coach ID (24-bit, little-endian)
+    Bytes 3-10  Tank levels, 1 byte each (0-100 = %, >100 = error code)
+                Order: Fresh, Wash, Toilet, Fresh2, Wash2, Toilet2, Wash3, LPG
+    Byte  11    Battery voltage * 10 (e.g. 130 = 13.0 V)
+    Bytes 12-13 Unused
+
+
+Sensor Numbers
+--------------
+
+    Number  BTP3 (0x0131)       BTP7 (0x0CC0)
+    ------  ----------------    ----------------
+      0     Fresh Water         Fresh Water
+      1     Toilet Water        Wash Water
+      2     Wash Water          Toilet Water
+      3     LPG                 Fresh Water 2
+      4     LPG 2               Wash Water 2
+      5     Galley Water        Toilet Water 2
+      6     Galley Water 2      Wash Water 3
+      7     Temperature         LPG
+      8     Temperature 2       Battery (voltage * 10)
+      9     Temperature 3       -
+     10     Temperature 4       -
+     11     Chemical            -
+     12     Chemical 2          -
+     13     Battery (voltage*10) -
+
+
+Status / Error Codes
+--------------------
+
+BTP3: the 3-char data field (bytes 4-6) may contain:
+    "OPN"   Sensor open / disconnected (no service created)
+    "ERR"   Sensor error (service shown with error status)
+    Numeric Actual sensor reading
+
+BTP7: tank byte values > 100 are error codes:
+    101  Short Circuit
+    102  Open / No response
+    103  Bitcount error
+    104  Non-stacked config with stacked data
+    105  Stacked, missing bottom sender
+    106  Stacked, missing top sender
+    108  Bad Checksum
+    110  Tank disabled
+    111  Tank init
+
+
+Unit Conversions
+----------------
+
+    Tank Level      Direct percentage (0-100)
+    Temperature     (°F - 32) * 5/9 = °C
+    Battery Voltage Value / 10 = Volts
+    Tank Capacity   Gallons * 0.00378541 = m³  (if volume desired)
+
+
+Victron D-Bus Mappings
+----------------------
+
+Product IDs:
+    Tank Sensor         0xA142  (VE_PROD_ID_TANK_SENSOR)
+    Temperature Sensor  0xA143  (VE_PROD_ID_TEMPERATURE_SENSOR)
+    Battery Monitor     0xA381  (VE_PROD_ID_BATTERY_MONITOR)
+
+Fluid Types:
+    Fresh Water  1  (FLUID_TYPE_FRESH_WATER)
+    Waste Water  2  (FLUID_TYPE_WASTE_WATER)
+    Black Water  5  (FLUID_TYPE_BLACK_WATER)
+    LPG          8  (FLUID_TYPE_LPG)
+    Chemical     0  (custom)
+
+
+References
+----------
+
+- Protocol decode: https://github.com/custom-components/ble_monitor/issues/1181
+- BTP7 btmon capture: https://github.com/TechBlueprints/victron-seelevel-python/issues/1
+- BTP7 PR discussion: https://github.com/TechBlueprints/victron-seelevel-python/pull/2
+- Original Python impl: https://github.com/TechBlueprints/victron-seelevel-python
+"""
+
 from ve_types import *
 from ble_device import BleDevice
 import logging
@@ -8,11 +117,10 @@ class BleDeviceSeeLevel(BleDevice):
     Shared base class for SeeLevel 709-BT protocols.
 
     Both BTP3 (manufacturer 305) and BTP7 (manufacturer 3264) share a common
-    advertisement header, tank level processing, and error handling. Subclasses
+    advertisement header, tank level processing, and error handling.  Subclasses
     provide protocol-specific parsing in handle_manufacturer_data().
 
-    Advertisement header (shared):
-        Bytes 0-2: Coach ID (24-bit, little-endian)
+    See module docstring for the full protocol reference.
     """
 
     CUSTOM_PARSING = True

--- a/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
@@ -1,0 +1,64 @@
+from ve_types import *
+from ble_device import BleDevice
+import logging
+
+
+class BleDeviceSeeLevel(BleDevice):
+    """
+    Shared base class for SeeLevel 709-BT protocols.
+
+    Both BTP3 (manufacturer 305) and BTP7 (manufacturer 3264) share a common
+    advertisement header, tank level processing, and error handling. Subclasses
+    provide protocol-specific parsing in handle_manufacturer_data().
+
+    Advertisement header (shared):
+        Bytes 0-2: Coach ID (24-bit, little-endian)
+    """
+
+    CUSTOM_PARSING = True
+
+    STATUS_CODES = {
+        101: "Short Circuit",
+        102: "Open",
+        103: "Bitcount error",
+        104: "Non-stacked config with stacked data",
+        105: "Stacked, missing bottom sender",
+        106: "Stacked, missing top sender",
+        108: "Bad Checksum",
+        110: "Tank disabled",
+        111: "Tank init",
+    }
+
+    def configure(self, manufacturer_data: bytes):
+        self.info.update({
+            'product_id': 0xA142,
+            'product_name': self.PRODUCT_NAME,
+            'device_name': 'SeeLevel',
+            'dev_prefix': 'seelevel',
+            'roles': dict(self.ROLES),
+            'regs': [],
+        })
+
+    def _parse_coach_id(self, manufacturer_data: bytes) -> int:
+        """Parse 24-bit little-endian coach ID from bytes 0-2."""
+        return int.from_bytes(manufacturer_data[0:3], byteorder='little')
+
+    def _build_tank_sensor_data(self, level: int, role_service) -> dict:
+        """Build D-Bus sensor data dict from a tank level percentage (0-100)."""
+        capacity = float(role_service['Capacity'] or 0)
+        remaining = round(capacity * level / 100.0, 3) if capacity else 0.0
+
+        return {
+            'RawValue': float(level),
+            'Level': level,
+            'Remaining': remaining,
+            'Status': 0,
+        }
+
+    def _set_error_status(self, role_service, error_code=None):
+        """Set error status on a role service. Logs the error code if known."""
+        if error_code is not None:
+            status_msg = self.STATUS_CODES.get(error_code, f"Unknown ({error_code})")
+            logging.debug(f"{self._plog} error: {status_msg}")
+        role_service['Status'] = 5
+        role_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
@@ -142,7 +142,7 @@ class BleDeviceSeeLevel(BleDevice):
             'product_id': 0xA142,
             'product_name': self.PRODUCT_NAME,
             'device_name': 'SeeLevel',
-            'dev_prefix': 'seelevel',
+            'dev_prefix': self.DEV_PREFIX,
             'roles': dict(self.ROLES),
             'regs': [],
         })

--- a/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
@@ -92,8 +92,8 @@ Product IDs:
 
 Fluid Types:
     Fresh Water  1  (FLUID_TYPE_FRESH_WATER)
-    Waste Water  2  (FLUID_TYPE_WASTE_WATER)
-    Black Water  5  (FLUID_TYPE_BLACK_WATER)
+    Wash Water   2  (FLUID_TYPE_WASTE_WATER)
+    Toilet Water 5  (FLUID_TYPE_BLACK_WATER)
     LPG          8  (FLUID_TYPE_LPG)
     Chemical     0  (custom)
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
@@ -1,0 +1,172 @@
+"""
+SeeLevel 709-BT Protocol Reference
+====================================
+
+The Garnet SeeLevel 709-BT is a BLE Broadcaster that continuously cycles
+through its connected sensors, transmitting advertisement packets.  No BLE
+connection is required -- all data is read from manufacturer-specific data
+in the advertisement PDU.
+
+Two hardware variants exist, distinguished by manufacturer ID:
+
+  BTP3 (Cypress)   MFG ID 305  (0x0131)
+  BTP7 (SeeLevel)  MFG ID 3264 (0x0CC0)
+
+
+BLE Packet Formats
+------------------
+
+BTP3 payload (14 bytes):
+    Bytes 0-2   Coach ID (24-bit, little-endian)
+    Byte  3     Sensor number (0-13)
+    Bytes 4-6   Sensor data (3 ASCII chars: "OPN", "ERR", or numeric)
+    Bytes 7-9   Volume in gallons (3 ASCII chars)
+    Bytes 10-12 Total capacity in gallons (3 ASCII chars)
+    Byte  13    Alarm state (ASCII digit '0'-'9')
+
+BTP7 payload (14 bytes):
+    Bytes 0-2   Coach ID (24-bit, little-endian)
+    Bytes 3-10  Tank levels, 1 byte each (0-100 = %, >100 = error code)
+                Order: Fresh, Wash, Toilet, Fresh2, Wash2, Toilet2, Wash3, LPG
+    Byte  11    Battery voltage * 10 (e.g. 130 = 13.0 V)
+    Bytes 12-13 Unused
+
+
+Sensor Numbers
+--------------
+
+    Number  BTP3 (0x0131)       BTP7 (0x0CC0)
+    ------  ----------------    ----------------
+      0     Fresh Water         Fresh Water
+      1     Toilet Water        Wash Water
+      2     Wash Water          Toilet Water
+      3     LPG                 Fresh Water 2
+      4     LPG 2               Wash Water 2
+      5     Galley Water        Toilet Water 2
+      6     Galley Water 2      Wash Water 3
+      7     Temperature         LPG
+      8     Temperature 2       Battery (voltage * 10)
+      9     Temperature 3       -
+     10     Temperature 4       -
+     11     Chemical            -
+     12     Chemical 2          -
+     13     Battery (voltage*10) -
+
+
+Status / Error Codes
+--------------------
+
+BTP3: the 3-char data field (bytes 4-6) may contain:
+    "OPN"   Sensor open / disconnected (no service created)
+    "ERR"   Sensor error (service shown with error status)
+    Numeric Actual sensor reading
+
+BTP7: tank byte values > 100 are error codes:
+    101  Short Circuit
+    102  Open / No response
+    103  Bitcount error
+    104  Non-stacked config with stacked data
+    105  Stacked, missing bottom sender
+    106  Stacked, missing top sender
+    108  Bad Checksum
+    110  Tank disabled
+    111  Tank init
+
+
+Unit Conversions
+----------------
+
+    Tank Level      Direct percentage (0-100)
+    Temperature     (°F - 32) * 5/9 = °C
+    Battery Voltage Value / 10 = Volts
+    Tank Capacity   Gallons * 0.00378541 = m³  (if volume desired)
+
+
+Victron D-Bus Mappings
+----------------------
+
+Product IDs:
+    Tank Sensor         0xA142  (VE_PROD_ID_TANK_SENSOR)
+    Temperature Sensor  0xA143  (VE_PROD_ID_TEMPERATURE_SENSOR)
+    Battery Monitor     0xA381  (VE_PROD_ID_BATTERY_MONITOR)
+
+Fluid Types:
+    Fresh Water  1  (FLUID_TYPE_FRESH_WATER)
+    Waste Water  2  (FLUID_TYPE_WASTE_WATER)
+    Black Water  5  (FLUID_TYPE_BLACK_WATER)
+    LPG          8  (FLUID_TYPE_LPG)
+    Chemical     0  (custom)
+
+
+References
+----------
+
+- Protocol decode: https://github.com/custom-components/ble_monitor/issues/1181
+- BTP7 btmon capture: https://github.com/TechBlueprints/victron-seelevel-python/issues/1
+- BTP7 PR discussion: https://github.com/TechBlueprints/victron-seelevel-python/pull/2
+- Original Python impl: https://github.com/TechBlueprints/victron-seelevel-python
+"""
+
+from ve_types import *
+from ble_device import BleDevice
+import logging
+
+
+class BleDeviceSeeLevel(BleDevice):
+    """
+    Shared base class for SeeLevel 709-BT protocols.
+
+    Both BTP3 (manufacturer 305) and BTP7 (manufacturer 3264) share a common
+    advertisement header, tank level processing, and error handling.  Subclasses
+    provide protocol-specific parsing in handle_manufacturer_data().
+
+    See module docstring for the full protocol reference.
+    """
+
+    CUSTOM_PARSING = True
+
+    STATUS_CODES = {
+        101: "Short Circuit",
+        102: "Open",
+        103: "Bitcount error",
+        104: "Non-stacked config with stacked data",
+        105: "Stacked, missing bottom sender",
+        106: "Stacked, missing top sender",
+        108: "Bad Checksum",
+        110: "Tank disabled",
+        111: "Tank init",
+    }
+
+    def configure(self, manufacturer_data: bytes):
+        self.info.update({
+            'product_id': 0xA142,
+            'product_name': self.PRODUCT_NAME,
+            'device_name': 'SeeLevel',
+            'dev_prefix': 'seelevel',
+            'roles': dict(self.ROLES),
+            'regs': [],
+        })
+
+    def _parse_coach_id(self, manufacturer_data: bytes) -> int:
+        """Parse 24-bit little-endian coach ID from bytes 0-2."""
+        return int.from_bytes(manufacturer_data[0:3], byteorder='little')
+
+    def _build_tank_sensor_data(self, level: int, role_service) -> dict:
+        """Build D-Bus sensor data dict from a tank level percentage (0-100)."""
+        capacity = float(role_service['Capacity'] or 0)
+        remaining = round(capacity * level / 100.0, 3) if capacity else 0.0
+
+        return {
+            'RawValue': float(level),
+            'Level': level,
+            'Remaining': remaining,
+            'Status': 0,
+        }
+
+    def _set_error_status(self, role_service, error_code=None):
+        """Set error status on a role service. Logs the error code if known."""
+        if error_code is not None:
+            status_msg = self.STATUS_CODES.get(error_code, f"Unknown ({error_code})")
+            logging.debug(f"{self._plog} error: {status_msg}")
+        role_service['Status'] = 5
+        role_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/conftest.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/conftest.py
@@ -1,0 +1,70 @@
+"""Shared test fixtures: stub D-Bus and GLib modules unavailable off-device."""
+import sys
+import os
+import types
+
+_src = os.path.join(os.path.dirname(__file__), '..')
+_ext = os.path.join(_src, 'ext')
+_velib = os.path.join(_ext, 'velib_python')
+for p in (_src, _ext, _velib):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# Stub modules that require system D-Bus / GLib (not available off-device).
+# Import chain: ble_device -> dbus_ble_service -> dbus_settings_service -> vedbus -> dbus
+# Import chain: ble_role_digitalinput -> gi.repository.GLib
+_stub_names = (
+    'dbus', 'dbus.bus', 'dbus.mainloop', 'dbus.mainloop.glib',
+    'dbus.service', 'dbus.exceptions',
+    'gi', 'gi.repository',
+    'vedbus', 'settingsdevice',
+    'dbus_settings_service', 'dbus_ble_service', 'dbus_role_service',
+)
+for _name in _stub_names:
+    if _name not in sys.modules:
+        sys.modules[_name] = types.ModuleType(_name)
+
+# Wire up dbus attribute hierarchy so `dbus.bus.BusConnection` resolves
+import dbus as _dbus_stub  # noqa: E402
+_dbus_stub.SystemBus = lambda **kw: None
+_dbus_stub.SessionBus = lambda **kw: None
+_dbus_stub.Interface = lambda *a, **kw: None
+_dbus_stub.String = str
+_dbus_stub.Bus = type('Bus', (), {})
+
+_dbus_bus_stub = sys.modules['dbus.bus']
+_dbus_bus_stub.BusConnection = type('BusConnection', (), {
+    'TYPE_SYSTEM': 'system',
+    'TYPE_SESSION': 'session',
+    '__new__': lambda cls, *a, **kw: object.__new__(cls),
+    'get_is_connected': lambda self: True,
+})
+_dbus_stub.bus = _dbus_bus_stub
+
+# GLib stub with enough surface for BleRoleDigitalInput (timeout_add_seconds)
+_gi_repo = sys.modules['gi.repository']
+_gi_repo.GLib = type('GLib', (), {
+    'timeout_add_seconds': staticmethod(lambda *a, **kw: None),
+    'idle_add': staticmethod(lambda *a, **kw: None),
+})()
+
+# DbusBleService fake
+import dbus_ble_service as _dbs_stub  # noqa: E402
+_fake_ble_svc = type('FakeBleService', (), {
+    'register_role_service': lambda self, *a: None,
+    'unregister_role_service': lambda self, *a: None,
+    '_get_value': lambda self, *a: 1,
+})()
+_dbs_stub.DbusBleService = type(
+    'DbusBleService', (), {'get': staticmethod(lambda: _fake_ble_svc)}
+)
+
+# DbusRoleService fake
+import dbus_role_service as _drs_stub  # noqa: E402
+_drs_stub.DbusRoleService = type('DbusRoleService', (), {})
+
+# vedbus fakes
+import vedbus as _vedbus_stub  # noqa: E402
+_vedbus_stub.VeDbusService = type('VeDbusService', (), {})
+_vedbus_stub.VeDbusItemImport = type('VeDbusItemImport', (), {})
+_vedbus_stub.VeDbusItemExport = type('VeDbusItemExport', (), {})

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -590,7 +590,7 @@ class TestBTP3ServiceCreation(unittest.TestCase):
 
         self.assertIn('battery_13', self.created)
         self.assertEqual(self.created['battery_13']._device_name, 'SeeLevel Voltage')
-        self.assertEqual(self.configs['battery_13'], {'custom_name': 'Voltage'})
+        self.assertEqual(self.configs['battery_13'], {'custom_name': 'SeeLevel Voltage'})
 
     def test_no_capacity_override_in_config(self):
         """Tank config only carries fluid_type and custom_name — capacity uses
@@ -618,7 +618,7 @@ class TestBTP3ServiceCreation(unittest.TestCase):
         self.assertEqual(self.configs['tank_00'], {'custom_name': 'Fresh Water', 'fluid_type': 1})
         self.assertEqual(self.configs['tank_01'], {'custom_name': 'Toilet Water', 'fluid_type': 5})
         self.assertEqual(self.configs['tank_02'], {'custom_name': 'Wash Water', 'fluid_type': 2})
-        self.assertEqual(self.configs['battery_13'], {'custom_name': 'Voltage'})
+        self.assertEqual(self.configs['battery_13'], {'custom_name': 'SeeLevel Voltage'})
 
 
 # ===================================================================
@@ -686,7 +686,7 @@ class TestBTP7ServiceCreation(unittest.TestCase):
         """Battery service has custom_name but no fluid_type in config."""
         self._init_device()
 
-        self.assertEqual(self.configs.get('battery_08'), {'custom_name': 'Voltage'})
+        self.assertEqual(self.configs.get('battery_08'), {'custom_name': 'SeeLevel Voltage'})
 
     def test_device_names_match_spec(self):
         """Each service gets the correct SeeLevel device name."""

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -476,7 +476,7 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
         self._patch_enabled()
         created = {}
 
-        def mock_create(role_type, index, device_name=None):
+        def mock_create(role_type, index, device_name=None, config=None):
             svc = _mock_create_service(self.dev, role_type, index,
                                        device_name=device_name,
                                        defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
@@ -489,33 +489,20 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
         self.assertIn('tank_00', created)
         self.assertEqual(created['tank_00']._device_name, 'SeeLevel Fresh Water')
 
-    def test_lazy_sets_fluid_type(self):
-        """Lazy creation sets FluidType from SENSORS table."""
+    def test_lazy_passes_fluid_type_in_config(self):
+        """Lazy creation passes fluid_type via config dict."""
         self._patch_enabled()
+        configs = {}
 
-        def mock_create(role_type, index, device_name=None):
+        def mock_create(role_type, index, device_name=None, config=None):
+            configs[f'{role_type}_{index:02d}'] = config
             return _mock_create_service(self.dev, role_type, index,
                                        defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
 
         self.dev._create_indexed_role_service = mock_create
         self.dev.handle_manufacturer_data(BTP3_TOILET_WATER_0PCT)
 
-        svc = self.dev._role_services['tank_01']
-        self.assertEqual(svc['FluidType'], 5)  # Black water
-
-    def test_lazy_zeroes_default_capacity(self):
-        """Lazy creation resets upstream default capacity 0.2 -> 0.0."""
-        self._patch_enabled()
-
-        def mock_create(role_type, index, device_name=None):
-            return _mock_create_service(self.dev, role_type, index,
-                                       defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
-
-        self.dev._create_indexed_role_service = mock_create
-        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
-
-        svc = self.dev._role_services['tank_00']
-        self.assertEqual(svc['Capacity'], 0.0)
+        self.assertEqual(configs['tank_01'], {'fluid_type': 5})
 
     # -- Disabled sensor -------------------------------------------------
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -563,7 +563,7 @@ class TestBTP3ServiceCreation(unittest.TestCase):
         self.assertEqual(self.configs['tank_00'], {'custom_name': 'Fresh Water', 'fluid_type': 1})
 
     def test_toilet_water_creates_tank_with_fluid_type_5(self):
-        """Sensor 1 (Toilet Water) -> tank service, fluid_type=5 (Black water)."""
+        """Sensor 1 (Toilet Water) -> tank service, fluid_type=5 (Toilet water)."""
         self.dev.handle_manufacturer_data(BTP3_TOILET_WATER_0PCT)
 
         self.assertIn('tank_01', self.created)
@@ -571,7 +571,7 @@ class TestBTP3ServiceCreation(unittest.TestCase):
         self.assertEqual(self.configs['tank_01'], {'custom_name': 'Toilet Water', 'fluid_type': 5})
 
     def test_wash_water_creates_tank_with_fluid_type_2(self):
-        """Sensor 2 (Wash Water) -> tank service, fluid_type=2 (Waste water)."""
+        """Sensor 2 (Wash Water) -> tank service, fluid_type=2 (Wash water)."""
         self.dev.handle_manufacturer_data(BTP3_WASH_WATER_0PCT)
 
         self.assertIn('tank_02', self.created)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -15,50 +15,6 @@ BTP7 capture — btmon, MAC D8:3B:DA:F8:24:06 (@atillack, GitHub issue
     battery 13.0 V.  Confirmed by @atillack: "hex value is 82 which is 130
     decimal - divide by 10.0 and you get the actual voltage of 13.0 V".
 """
-import sys
-import os
-import types
-
-sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext'))
-sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext', 'velib_python'))
-
-# Stub modules that require system D-Bus (not available off-device).
-# Import chain: seelevel_common -> ble_device -> dbus_ble_service ->
-# dbus_settings_service -> vedbus -> dbus.
-_stub_names = (
-    'dbus', 'dbus.mainloop', 'dbus.mainloop.glib',
-    'dbus.service', 'dbus.exceptions',
-    'vedbus', 'settingsdevice',
-    'dbus_settings_service', 'dbus_ble_service', 'dbus_role_service',
-)
-for _name in _stub_names:
-    if _name not in sys.modules:
-        sys.modules[_name] = types.ModuleType(_name)
-
-import dbus as _dbus_stub
-_dbus_stub.SystemBus = lambda **kw: None
-_dbus_stub.SessionBus = lambda **kw: None
-_dbus_stub.Interface = lambda *a, **kw: None
-_dbus_stub.String = str
-_dbus_stub.Bus = type('Bus', (), {})
-
-import dbus_ble_service as _dbs_stub
-_fake_ble_svc = type('FakeBleService', (), {
-    'register_role_service': lambda self, *a: None,
-    'unregister_role_service': lambda self, *a: None,
-    '_get_value': lambda self, *a: 1,
-})()
-_dbs_stub.DbusBleService = type('DbusBleService', (), {'get': staticmethod(lambda: _fake_ble_svc)})
-
-import dbus_role_service as _drs_stub
-_drs_stub.DbusRoleService = type('DbusRoleService', (), {})
-
-import vedbus as _vedbus_stub
-_vedbus_stub.VeDbusService = type('VeDbusService', (), {})
-_vedbus_stub.VeDbusItemImport = type('VeDbusItemImport', (), {})
-_vedbus_stub.VeDbusItemExport = type('VeDbusItemExport', (), {})
-
 import unittest
 from ble_device_seelevel_btp3 import BleDeviceSeeLevelBTP3
 from ble_device_seelevel_btp7 import BleDeviceSeeLevelBTP7

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -508,7 +508,7 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
         self.dev._create_indexed_role_service = mock_create
         self.dev.handle_manufacturer_data(BTP3_TOILET_WATER_0PCT)
 
-        self.assertEqual(configs['tank_01'], {'fluid_type': 5})
+        self.assertEqual(configs['tank_01'], {'custom_name': 'Toilet Water', 'fluid_type': 5})
 
     # -- Disabled sensor -------------------------------------------------
 
@@ -560,7 +560,7 @@ class TestBTP3ServiceCreation(unittest.TestCase):
 
         self.assertIn('tank_00', self.created)
         self.assertEqual(self.created['tank_00']._device_name, 'SeeLevel Fresh Water')
-        self.assertEqual(self.configs['tank_00'], {'fluid_type': 1})
+        self.assertEqual(self.configs['tank_00'], {'custom_name': 'Fresh Water', 'fluid_type': 1})
 
     def test_toilet_water_creates_tank_with_fluid_type_5(self):
         """Sensor 1 (Toilet Water) -> tank service, fluid_type=5 (Black water)."""
@@ -568,7 +568,7 @@ class TestBTP3ServiceCreation(unittest.TestCase):
 
         self.assertIn('tank_01', self.created)
         self.assertEqual(self.created['tank_01']._device_name, 'SeeLevel Toilet Water')
-        self.assertEqual(self.configs['tank_01'], {'fluid_type': 5})
+        self.assertEqual(self.configs['tank_01'], {'custom_name': 'Toilet Water', 'fluid_type': 5})
 
     def test_wash_water_creates_tank_with_fluid_type_2(self):
         """Sensor 2 (Wash Water) -> tank service, fluid_type=2 (Waste water)."""
@@ -576,7 +576,7 @@ class TestBTP3ServiceCreation(unittest.TestCase):
 
         self.assertIn('tank_02', self.created)
         self.assertEqual(self.created['tank_02']._device_name, 'SeeLevel Wash Water')
-        self.assertEqual(self.configs['tank_02'], {'fluid_type': 2})
+        self.assertEqual(self.configs['tank_02'], {'custom_name': 'Wash Water', 'fluid_type': 2})
 
     def test_lpg_opn_creates_nothing(self):
         """Sensor 3 (LPG), value OPN -> no service created."""
@@ -590,15 +590,16 @@ class TestBTP3ServiceCreation(unittest.TestCase):
 
         self.assertIn('battery_13', self.created)
         self.assertEqual(self.created['battery_13']._device_name, 'SeeLevel Voltage')
-        self.assertEqual(self.configs['battery_13'], {})
+        self.assertEqual(self.configs['battery_13'], {'custom_name': 'Voltage'})
 
     def test_no_capacity_override_in_config(self):
-        """Tank config only carries fluid_type — capacity uses the role default
-        (0.2 m³) until the user configures it."""
+        """Tank config only carries fluid_type and custom_name — capacity uses
+        the role default (0.2 m³) until the user configures it."""
         self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
 
         self.assertNotIn('capacity', self.configs['tank_00'])
-        self.assertEqual(list(self.configs['tank_00'].keys()), ['fluid_type'])
+        self.assertIn('fluid_type', self.configs['tank_00'])
+        self.assertIn('custom_name', self.configs['tank_00'])
 
     def test_all_connected_sensors_from_airstream(self):
         """Feed all 5 real Airstream captures: 3 tanks + 1 OPN + 1 battery."""
@@ -614,10 +615,10 @@ class TestBTP3ServiceCreation(unittest.TestCase):
         self.assertNotIn('tank_03', self.created)
         self.assertIn('battery_13', self.created)
 
-        self.assertEqual(self.configs['tank_00'], {'fluid_type': 1})
-        self.assertEqual(self.configs['tank_01'], {'fluid_type': 5})
-        self.assertEqual(self.configs['tank_02'], {'fluid_type': 2})
-        self.assertEqual(self.configs['battery_13'], {})
+        self.assertEqual(self.configs['tank_00'], {'custom_name': 'Fresh Water', 'fluid_type': 1})
+        self.assertEqual(self.configs['tank_01'], {'custom_name': 'Toilet Water', 'fluid_type': 5})
+        self.assertEqual(self.configs['tank_02'], {'custom_name': 'Wash Water', 'fluid_type': 2})
+        self.assertEqual(self.configs['battery_13'], {'custom_name': 'Voltage'})
 
 
 # ===================================================================
@@ -667,24 +668,25 @@ class TestBTP7ServiceCreation(unittest.TestCase):
         self._init_device()
 
         expected = {
-            'tank_00': 1,   # Fresh Water
-            'tank_01': 2,   # Wash Water
-            'tank_02': 5,   # Toilet Water (Black)
-            'tank_03': 1,   # Fresh Water 2
-            'tank_04': 2,   # Wash Water 2
-            'tank_05': 5,   # Toilet Water 2
-            'tank_06': 2,   # Wash Water 3
-            'tank_07': 8,   # LPG
+            'tank_00': (1, 'Fresh Water'),
+            'tank_01': (2, 'Wash Water'),
+            'tank_02': (5, 'Toilet Water'),
+            'tank_03': (1, 'Fresh Water 2'),
+            'tank_04': (2, 'Wash Water 2'),
+            'tank_05': (5, 'Toilet Water 2'),
+            'tank_06': (2, 'Wash Water 3'),
+            'tank_07': (8, 'LPG'),
         }
-        for key, fluid in expected.items():
-            self.assertEqual(self.configs[key], {'fluid_type': fluid},
-                             f"{key} should have fluid_type={fluid}")
+        for key, (fluid, name) in expected.items():
+            self.assertEqual(self.configs[key],
+                             {'fluid_type': fluid, 'custom_name': name},
+                             f"{key} should have fluid_type={fluid}, custom_name={name!r}")
 
     def test_battery_has_no_fluid_type(self):
-        """Battery service has no fluid_type in config."""
+        """Battery service has custom_name but no fluid_type in config."""
         self._init_device()
 
-        self.assertIsNone(self.configs.get('battery_08'))
+        self.assertEqual(self.configs.get('battery_08'), {'custom_name': 'Voltage'})
 
     def test_device_names_match_spec(self):
         """Each service gets the correct SeeLevel device name."""

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -174,8 +174,8 @@ def _make_device(cls, mac='00a0508d9569'):
     dev._plog = 'test:'
     dev.info = {
         'dev_mac': mac,
-        'dev_id': f'seelevel_{mac}',
-        'dev_prefix': 'seelevel',
+        'dev_id': f'{cls.DEV_PREFIX}_{mac}',
+        'dev_prefix': cls.DEV_PREFIX,
         'product_id': 0xA142,
         'product_name': cls.PRODUCT_NAME,
         'device_name': 'SeeLevel',

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -15,6 +15,7 @@ BTP7 capture — btmon, MAC D8:3B:DA:F8:24:06 (@atillack, GitHub issue
     battery 13.0 V.  Confirmed by @atillack: "hex value is 82 which is 130
     decimal - divide by 10.0 and you get the actual voltage of 13.0 V".
 """
+import os
 import unittest
 from ble_device_seelevel_btp3 import BleDeviceSeeLevelBTP3
 from ble_device_seelevel_btp7 import BleDeviceSeeLevelBTP7
@@ -521,6 +522,188 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
 
         self.assertNotIn('Level', svc)
         self.assertFalse(svc.connected)
+
+
+# ===================================================================
+# BTP3 — service creation from raw captures (end-to-end)
+# ===================================================================
+
+class TestBTP3ServiceCreation(unittest.TestCase):
+    """
+    Feed every raw BTP3 capture and verify:
+      - correct services are created with expected fluid_type config
+      - correct device names are assigned
+      - OPN sensors never create a service
+      - battery sensor creates a battery service (no fluid_type)
+    """
+
+    def setUp(self):
+        self.dev = _make_device(BleDeviceSeeLevelBTP3)
+        self.dev._is_indexed_role_enabled = lambda *a: True
+        self.created = {}
+        self.configs = {}
+
+        def mock_create(role_type, index, device_name=None, config=None):
+            key = f'{role_type}_{index:02d}'
+            self.configs[key] = config
+            svc = _mock_create_service(self.dev, role_type, index,
+                                       device_name=device_name,
+                                       defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
+            self.created[key] = svc
+            return svc
+
+        self.dev._create_indexed_role_service = mock_create
+
+    def test_fresh_water_creates_tank_with_fluid_type_1(self):
+        """Sensor 0 (Fresh Water) -> tank service, fluid_type=1 (Fresh water)."""
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertIn('tank_00', self.created)
+        self.assertEqual(self.created['tank_00']._device_name, 'SeeLevel Fresh Water')
+        self.assertEqual(self.configs['tank_00'], {'fluid_type': 1})
+
+    def test_toilet_water_creates_tank_with_fluid_type_5(self):
+        """Sensor 1 (Toilet Water) -> tank service, fluid_type=5 (Black water)."""
+        self.dev.handle_manufacturer_data(BTP3_TOILET_WATER_0PCT)
+
+        self.assertIn('tank_01', self.created)
+        self.assertEqual(self.created['tank_01']._device_name, 'SeeLevel Toilet Water')
+        self.assertEqual(self.configs['tank_01'], {'fluid_type': 5})
+
+    def test_wash_water_creates_tank_with_fluid_type_2(self):
+        """Sensor 2 (Wash Water) -> tank service, fluid_type=2 (Waste water)."""
+        self.dev.handle_manufacturer_data(BTP3_WASH_WATER_0PCT)
+
+        self.assertIn('tank_02', self.created)
+        self.assertEqual(self.created['tank_02']._device_name, 'SeeLevel Wash Water')
+        self.assertEqual(self.configs['tank_02'], {'fluid_type': 2})
+
+    def test_lpg_opn_creates_nothing(self):
+        """Sensor 3 (LPG), value OPN -> no service created."""
+        self.dev.handle_manufacturer_data(BTP3_LPG_OPEN)
+
+        self.assertEqual(len(self.created), 0)
+
+    def test_battery_creates_battery_service(self):
+        """Sensor 13 (Voltage) -> battery service, no fluid_type."""
+        self.dev.handle_manufacturer_data(BTP3_BATTERY_13V7)
+
+        self.assertIn('battery_13', self.created)
+        self.assertEqual(self.created['battery_13']._device_name, 'SeeLevel Voltage')
+        self.assertEqual(self.configs['battery_13'], {})
+
+    def test_no_capacity_override_in_config(self):
+        """Tank config only carries fluid_type — capacity uses the role default
+        (0.2 m³) until the user configures it."""
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertNotIn('capacity', self.configs['tank_00'])
+        self.assertEqual(list(self.configs['tank_00'].keys()), ['fluid_type'])
+
+    def test_all_connected_sensors_from_airstream(self):
+        """Feed all 5 real Airstream captures: 3 tanks + 1 OPN + 1 battery."""
+        for payload in (BTP3_FRESH_WATER_0PCT, BTP3_TOILET_WATER_0PCT,
+                        BTP3_WASH_WATER_0PCT, BTP3_LPG_OPEN,
+                        BTP3_BATTERY_13V7):
+            self.dev.handle_manufacturer_data(payload)
+
+        self.assertEqual(len(self.created), 4)
+        self.assertIn('tank_00', self.created)
+        self.assertIn('tank_01', self.created)
+        self.assertIn('tank_02', self.created)
+        self.assertNotIn('tank_03', self.created)
+        self.assertIn('battery_13', self.created)
+
+        self.assertEqual(self.configs['tank_00'], {'fluid_type': 1})
+        self.assertEqual(self.configs['tank_01'], {'fluid_type': 5})
+        self.assertEqual(self.configs['tank_02'], {'fluid_type': 2})
+        self.assertEqual(self.configs['battery_13'], {})
+
+
+# ===================================================================
+# BTP7 — service creation from raw capture (end-to-end)
+# ===================================================================
+
+class TestBTP7ServiceCreation(unittest.TestCase):
+    """
+    BTP7 creates all 8 tank slots + 1 battery in init(). Verify
+    the config passed for each carries the correct fluid_type from
+    TANK_SLOTS.
+    """
+
+    def setUp(self):
+        from ble_role import BleRole
+        BleRole.load_classes(os.path.dirname(os.path.abspath(__file__)))
+
+        self.dev = _make_device(BleDeviceSeeLevelBTP7, 'd83bdaf82406')
+        self.configs = {}
+
+        def mock_create(role_type, index, device_name=None, config=None):
+            key = f'{role_type}_{index:02d}'
+            self.configs[key] = config
+            return _mock_create_service(self.dev, role_type, index,
+                                       device_name=device_name,
+                                       defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
+
+        self.dev._create_indexed_role_service = mock_create
+
+    def _init_device(self):
+        self.dev.info['roles'] = dict(BleDeviceSeeLevelBTP7.ROLES)
+        self.dev.info['regs'] = []
+        self.dev._load_configuration()
+        self.dev.init()
+
+    def test_all_slots_created(self):
+        """init() creates 8 tank slots + 1 battery = 9 services."""
+        self._init_device()
+
+        self.assertEqual(len(self.dev._role_services), 9)
+        for slot in range(8):
+            self.assertIn(f'tank_{slot:02d}', self.dev._role_services)
+        self.assertIn('battery_08', self.dev._role_services)
+
+    def test_tank_fluid_types_match_spec(self):
+        """Each tank slot's config carries the correct fluid_type."""
+        self._init_device()
+
+        expected = {
+            'tank_00': 1,   # Fresh Water
+            'tank_01': 2,   # Wash Water
+            'tank_02': 5,   # Toilet Water (Black)
+            'tank_03': 1,   # Fresh Water 2
+            'tank_04': 2,   # Wash Water 2
+            'tank_05': 5,   # Toilet Water 2
+            'tank_06': 2,   # Wash Water 3
+            'tank_07': 8,   # LPG
+        }
+        for key, fluid in expected.items():
+            self.assertEqual(self.configs[key], {'fluid_type': fluid},
+                             f"{key} should have fluid_type={fluid}")
+
+    def test_battery_has_no_fluid_type(self):
+        """Battery service has no fluid_type in config."""
+        self._init_device()
+
+        self.assertIsNone(self.configs.get('battery_08'))
+
+    def test_device_names_match_spec(self):
+        """Each service gets the correct SeeLevel device name."""
+        self._init_device()
+
+        expected_names = {
+            'tank_00': 'SeeLevel Fresh Water',
+            'tank_01': 'SeeLevel Wash Water',
+            'tank_02': 'SeeLevel Toilet Water',
+            'tank_03': 'SeeLevel Fresh Water 2',
+            'tank_04': 'SeeLevel Wash Water 2',
+            'tank_05': 'SeeLevel Toilet Water 2',
+            'tank_06': 'SeeLevel Wash Water 3',
+            'tank_07': 'SeeLevel LPG',
+            'battery_08': 'SeeLevel Voltage',
+        }
+        for key, name in expected_names.items():
+            svc = self.dev._role_services[key]
+            self.assertEqual(svc._device_name, name, f"{key} should be named {name!r}")
 
 
 # ===================================================================

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -1,0 +1,626 @@
+"""
+Tests for SeeLevel BTP3 and BTP7 BLE advertisement parsing.
+
+All test payloads below are real captures unless explicitly marked synthetic.
+
+BTP3 captures — Cerbo GX, MAC 00:A0:50:8D:95:69 (2025 Airstream Flying Cloud)
+    Coach ID 0x699589 (bytes 8d 95 69, little-endian)
+    5 active sensors cycling: 0 (Fresh), 1 (Toilet), 2 (Wash), 3 (LPG), 13 (Battery)
+    Sensors 4-12 not connected to hardware — never appear in advertisements.
+
+BTP7 capture — btmon, MAC D8:3B:DA:F8:24:06 (@atillack, GitHub issue
+    TechBlueprints/victron-seelevel-python#1)
+    Coach ID 0x000491 (bytes 91 04 00, little-endian)
+    3 active tanks (Fresh=25%, Wash=0%, Toilet=0%), 5 disabled (code 110),
+    battery 13.0 V.  Confirmed by @atillack: "hex value is 82 which is 130
+    decimal - divide by 10.0 and you get the actual voltage of 13.0 V".
+"""
+import sys
+import os
+import types
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext', 'velib_python'))
+
+# Stub modules that require system D-Bus (not available off-device).
+# Import chain: seelevel_common -> ble_device -> dbus_ble_service ->
+# dbus_settings_service -> vedbus -> dbus.
+_stub_names = (
+    'dbus', 'dbus.mainloop', 'dbus.mainloop.glib',
+    'dbus.service', 'dbus.exceptions',
+    'vedbus', 'settingsdevice',
+    'dbus_settings_service', 'dbus_ble_service', 'dbus_role_service',
+)
+for _name in _stub_names:
+    if _name not in sys.modules:
+        sys.modules[_name] = types.ModuleType(_name)
+
+import dbus as _dbus_stub
+_dbus_stub.SystemBus = lambda **kw: None
+_dbus_stub.SessionBus = lambda **kw: None
+_dbus_stub.Interface = lambda *a, **kw: None
+_dbus_stub.String = str
+_dbus_stub.Bus = type('Bus', (), {})
+
+import dbus_ble_service as _dbs_stub
+_fake_ble_svc = type('FakeBleService', (), {
+    'register_role_service': lambda self, *a: None,
+    'unregister_role_service': lambda self, *a: None,
+    '_get_value': lambda self, *a: 1,
+})()
+_dbs_stub.DbusBleService = type('DbusBleService', (), {'get': staticmethod(lambda: _fake_ble_svc)})
+
+import dbus_role_service as _drs_stub
+_drs_stub.DbusRoleService = type('DbusRoleService', (), {})
+
+import vedbus as _vedbus_stub
+_vedbus_stub.VeDbusService = type('VeDbusService', (), {})
+_vedbus_stub.VeDbusItemImport = type('VeDbusItemImport', (), {})
+_vedbus_stub.VeDbusItemExport = type('VeDbusItemExport', (), {})
+
+import unittest
+from ble_device_seelevel_btp3 import BleDeviceSeeLevelBTP3
+from ble_device_seelevel_btp7 import BleDeviceSeeLevelBTP7
+
+
+# ===================================================================
+# Raw captures
+# ===================================================================
+
+# -- BTP3: Cerbo GX, MAC 00:A0:50:8D:95:69 -------------------------
+#
+# Coach ID = 8d 95 69  (0x699589 LE)
+# Byte 3   = sensor number
+# Bytes 4-6 = 3 ASCII chars (value)
+# Bytes 7-9 = volume (gallons), 10-12 = capacity (gallons)
+# Byte 13  = alarm ('0'-'9')
+
+BTP3_FRESH_WATER_0PCT  = b'\x8d\x95i\x00  00000000'   # sensor 0, val "  0"
+BTP3_TOILET_WATER_0PCT = b'\x8d\x95i\x01  00000000'   # sensor 1, val "  0"
+BTP3_WASH_WATER_0PCT   = b'\x8d\x95i\x02  00000000'   # sensor 2, val "  0"
+BTP3_LPG_OPEN          = b'\x8d\x95i\x03OPN0000000'   # sensor 3, val "OPN"
+BTP3_BATTERY_13V7      = b'\x8d\x95i\r1370000000'     # sensor 13, val "137"
+
+# -- BTP7: btmon, MAC D8:3B:DA:F8:24:06 ----------------------------
+#
+# Raw hex from btmon: 9104001900006e6e6e6e6e820000
+#
+#   91 04 00   coach ID (0x000491 LE)
+#   19         Fresh  = 25%
+#   00         Wash   =  0%
+#   00         Toilet =  0%
+#   6e         Fresh2 = 110 (tank disabled)
+#   6e         Wash2  = 110
+#   6e         Toilet2= 110
+#   6e         Wash3  = 110
+#   6e         LPG    = 110
+#   82         Battery= 130 -> 13.0 V
+#   00 00      unused
+
+BTP7_CAPTURE = bytes.fromhex('9104001900006e6e6e6e6e820000')
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+class MockRoleService(dict):
+    """Dict-like stand-in for DbusRoleService (no D-Bus required)."""
+
+    def __init__(self, defaults=None):
+        super().__init__(defaults or {})
+        self.connected = False
+
+    def connect(self):
+        self.connected = True
+
+    def disconnect(self):
+        self.connected = False
+
+    def get_dev_id(self):
+        return 'test_dev'
+
+    def get_dbus_id(self):
+        return 'test_dev/tank'
+
+
+def _make_device(cls, mac='00a0508d9569'):
+    """Instantiate a SeeLevel device without D-Bus, wiring up minimal state."""
+    dev = cls.__new__(cls)
+    dev._role_services = {}
+    dev._plog = 'test:'
+    dev.info = {
+        'dev_mac': mac,
+        'dev_id': f'seelevel_{mac}',
+        'dev_prefix': 'seelevel',
+        'product_id': 0xA142,
+        'product_name': cls.PRODUCT_NAME,
+        'device_name': 'SeeLevel',
+        'hardware_version': '1.0.0',
+        'firmware_version': '1.0.0',
+        'roles': dict(cls.ROLES),
+        'regs': [],
+        'settings': [],
+        'alarms': [],
+    }
+    return dev
+
+
+def _mock_create_service(dev, role_type, index, device_name=None, defaults=None):
+    """Register a MockRoleService in the device's _role_services dict."""
+    key = f'{role_type}_{index:02d}'
+    svc = MockRoleService(defaults or {})
+    svc._device_name = device_name
+    dev._role_services[key] = svc
+    return svc
+
+
+# ===================================================================
+# BTP3 — check_manufacturer_data
+# ===================================================================
+
+class TestBTP3CheckManufacturerData(unittest.TestCase):
+
+    def setUp(self):
+        self.dev = _make_device(BleDeviceSeeLevelBTP3)
+
+    def test_accepts_sensor_0(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_FRESH_WATER_0PCT))
+
+    def test_accepts_sensor_1(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_TOILET_WATER_0PCT))
+
+    def test_accepts_sensor_2(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_WASH_WATER_0PCT))
+
+    def test_accepts_sensor_3_opn(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_LPG_OPEN))
+
+    def test_accepts_sensor_13_battery(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_BATTERY_13V7))
+
+    def test_rejects_too_short(self):
+        self.assertFalse(self.dev.check_manufacturer_data(
+            BTP3_FRESH_WATER_0PCT[:6]))
+
+    def test_rejects_unknown_sensor_14(self):
+        # synthetic: sensor number 14 does not exist
+        self.assertFalse(self.dev.check_manufacturer_data(
+            b'\x8d\x95i\x0e0000000000'))
+
+
+# ===================================================================
+# BTP3 — handle_manufacturer_data
+# ===================================================================
+
+class TestBTP3HandleManufacturerData(unittest.TestCase):
+
+    def setUp(self):
+        self.dev = _make_device(BleDeviceSeeLevelBTP3)
+
+    def _enable_sensor(self, role_type, index, defaults=None):
+        return _mock_create_service(self.dev, role_type, index, defaults=defaults)
+
+    def _patch_enabled(self):
+        self.dev._is_indexed_role_enabled = lambda *a: True
+
+    # -- Real BTP3 captures: tanks at 0% --------------------------------
+
+    def test_fresh_water_0pct(self):
+        """Real capture: sensor 0 (Fresh Water), value '  0' -> 0%."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertEqual(svc['Level'], 0)
+        self.assertEqual(svc['RawValue'], 0.0)
+        self.assertEqual(svc['Remaining'], 0.0)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    def test_toilet_water_0pct(self):
+        """Real capture: sensor 1 (Toilet Water), value '  0' -> 0%."""
+        svc = self._enable_sensor('tank', 1, {
+            'FluidType': 5, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_TOILET_WATER_0PCT)
+
+        self.assertEqual(svc['Level'], 0)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    def test_wash_water_0pct(self):
+        """Real capture: sensor 2 (Wash Water), value '  0' -> 0%."""
+        svc = self._enable_sensor('tank', 2, {
+            'FluidType': 2, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_WASH_WATER_0PCT)
+
+        self.assertEqual(svc['Level'], 0)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    # -- Real BTP3 capture: OPN (disconnected) ---------------------------
+
+    def test_lpg_opn_skipped(self):
+        """Real capture: sensor 3 (LPG), value 'OPN' -> no update."""
+        svc = self._enable_sensor('tank', 3, {
+            'FluidType': 8, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_LPG_OPEN)
+
+        self.assertNotIn('Level', svc)
+        self.assertFalse(svc.connected)
+
+    # -- Real BTP3 capture: battery voltage ------------------------------
+
+    def test_battery_13v7(self):
+        """Real capture: sensor 13, value '137' -> 13.7 V."""
+        svc = self._enable_sensor('battery', 13, {'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_BATTERY_13V7)
+
+        self.assertAlmostEqual(svc['/Dc/0/Voltage'], 13.7, places=1)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    # -- Real capture: alarm byte ----------------------------------------
+
+    def test_alarm_byte_zero_from_real_capture(self):
+        """Real capture: all captured payloads have alarm byte '0' (0x30)."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertEqual(svc['/Alarms/Low/State'], 0)
+
+    # -- Synthetic: cases not covered by real hardware -------------------
+
+    def test_err_sets_error_status(self):
+        """Synthetic: sensor 0, value 'ERR' -> Status 5."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00ERR0000000')
+
+        self.assertEqual(svc['Status'], 5)
+        self.assertTrue(svc.connected)
+
+    def test_tank_50pct_with_capacity(self):
+        """Synthetic: sensor 0 at 50%, capacity 0.2 m3 -> remaining 0.1."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.2, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 500000000')
+
+        self.assertEqual(svc['Level'], 50)
+        self.assertAlmostEqual(svc['Remaining'], 0.1, places=3)
+
+    def test_tank_clamps_to_100(self):
+        """Synthetic: value > 100 is clamped to 100%."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x001200000000')
+
+        self.assertEqual(svc['Level'], 100)
+
+    def test_alarm_nonzero(self):
+        """Synthetic: alarm byte '3' -> low alarm active."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 100000003')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 1)
+
+    def test_temperature_72f(self):
+        """Synthetic: sensor 7 (Temp), value '072' (72 degF) -> 22.2 degC."""
+        svc = self._enable_sensor('temperature', 7, {'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x070720000000')
+
+        self.assertAlmostEqual(svc['Temperature'], 22.2, places=1)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    def test_temperature_32f_freezing(self):
+        """Synthetic: sensor 7, value '032' (32 degF) -> 0.0 degC."""
+        svc = self._enable_sensor('temperature', 7, {'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x070320000000')
+
+        self.assertAlmostEqual(svc['Temperature'], 0.0, places=1)
+
+    def test_battery_low_voltage(self):
+        """Synthetic: sensor 13, value '108' -> 10.8 V."""
+        svc = self._enable_sensor('battery', 13, {'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\r1080000000')
+
+        self.assertAlmostEqual(svc['/Dc/0/Voltage'], 10.8, places=1)
+
+    def test_unparseable_value_ignored(self):
+        """Synthetic: non-numeric, non-OPN/ERR data -> no crash."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00XYZ0000000')
+
+        self.assertNotIn('Level', svc)
+
+    # -- Lazy service creation (uses real capture to trigger) ------------
+
+    def test_lazy_creates_tank_service(self):
+        """Real capture triggers lazy creation of tank service."""
+        self._patch_enabled()
+        created = {}
+
+        def mock_create(role_type, index, device_name=None):
+            svc = _mock_create_service(self.dev, role_type, index,
+                                       device_name=device_name,
+                                       defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
+            created[f'{role_type}_{index:02d}'] = svc
+            return svc
+
+        self.dev._create_indexed_role_service = mock_create
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertIn('tank_00', created)
+        self.assertEqual(created['tank_00']._device_name, 'SeeLevel Fresh Water')
+
+    def test_lazy_sets_fluid_type(self):
+        """Lazy creation sets FluidType from SENSORS table."""
+        self._patch_enabled()
+
+        def mock_create(role_type, index, device_name=None):
+            return _mock_create_service(self.dev, role_type, index,
+                                       defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
+
+        self.dev._create_indexed_role_service = mock_create
+        self.dev.handle_manufacturer_data(BTP3_TOILET_WATER_0PCT)
+
+        svc = self.dev._role_services['tank_01']
+        self.assertEqual(svc['FluidType'], 5)  # Black water
+
+    def test_lazy_zeroes_default_capacity(self):
+        """Lazy creation resets upstream default capacity 0.2 -> 0.0."""
+        self._patch_enabled()
+
+        def mock_create(role_type, index, device_name=None):
+            return _mock_create_service(self.dev, role_type, index,
+                                       defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
+
+        self.dev._create_indexed_role_service = mock_create
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        svc = self.dev._role_services['tank_00']
+        self.assertEqual(svc['Capacity'], 0.0)
+
+    # -- Disabled sensor -------------------------------------------------
+
+    def test_disabled_sensor_not_updated(self):
+        """Real capture, but sensor disabled -> no D-Bus update."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self.dev._is_indexed_role_enabled = lambda *a: False
+
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertNotIn('Level', svc)
+        self.assertFalse(svc.connected)
+
+
+# ===================================================================
+# BTP7 — check_manufacturer_data
+# ===================================================================
+
+class TestBTP7CheckManufacturerData(unittest.TestCase):
+
+    def setUp(self):
+        self.dev = _make_device(BleDeviceSeeLevelBTP7, 'd83bdaf82406')
+
+    def test_accepts_real_capture(self):
+        """Real btmon capture: 14 bytes."""
+        self.assertTrue(self.dev.check_manufacturer_data(BTP7_CAPTURE))
+
+    def test_accepts_minimum_12_bytes(self):
+        """12 bytes is the minimum for tank + battery."""
+        self.assertTrue(self.dev.check_manufacturer_data(BTP7_CAPTURE[:12]))
+
+    def test_rejects_11_bytes(self):
+        """11 bytes is too short (missing battery byte)."""
+        self.assertFalse(self.dev.check_manufacturer_data(BTP7_CAPTURE[:11]))
+
+
+# ===================================================================
+# BTP7 — handle_manufacturer_data (real capture)
+# ===================================================================
+
+class TestBTP7HandleManufacturerData(unittest.TestCase):
+    """
+    All tests in this class use the real btmon capture from @atillack
+    (GitHub TechBlueprints/victron-seelevel-python#1) unless marked synthetic.
+    """
+
+    def setUp(self):
+        self.dev = _make_device(BleDeviceSeeLevelBTP7, 'd83bdaf82406')
+        self.dev._is_indexed_role_enabled = lambda *a: True
+
+        for slot in range(8):
+            name, fluid = BleDeviceSeeLevelBTP7.TANK_SLOTS[slot]
+            _mock_create_service(self.dev, 'tank', slot, device_name=f'SeeLevel {name}',
+                                 defaults={'FluidType': fluid, 'Capacity': 0.0, 'Status': 0})
+        _mock_create_service(self.dev, 'battery', 8, device_name='SeeLevel Voltage',
+                             defaults={'Status': 0})
+
+    # -- Active tanks from real capture ----------------------------------
+
+    def test_fresh_water_25pct(self):
+        """Byte 3 = 0x19 = 25 -> Fresh Water at 25%."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['tank_00']
+        self.assertEqual(svc['Level'], 25)
+        self.assertEqual(svc['RawValue'], 25.0)
+        self.assertEqual(svc['Remaining'], 0.0)
+        self.assertTrue(svc.connected)
+
+    def test_wash_water_0pct(self):
+        """Byte 4 = 0x00 -> Wash Water at 0%."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['tank_01']
+        self.assertEqual(svc['Level'], 0)
+        self.assertTrue(svc.connected)
+
+    def test_toilet_water_0pct(self):
+        """Byte 5 = 0x00 -> Toilet Water at 0%."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['tank_02']
+        self.assertEqual(svc['Level'], 0)
+        self.assertTrue(svc.connected)
+
+    # -- Disabled tanks from real capture (code 110) ---------------------
+
+    def test_fresh2_disabled(self):
+        """Byte 6 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_03']['Status'], 5)
+
+    def test_wash2_disabled(self):
+        """Byte 7 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_04']['Status'], 5)
+
+    def test_toilet2_disabled(self):
+        """Byte 8 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_05']['Status'], 5)
+
+    def test_wash3_disabled(self):
+        """Byte 9 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_06']['Status'], 5)
+
+    def test_lpg_disabled(self):
+        """Byte 10 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_07']['Status'], 5)
+
+    # -- Battery voltage from real capture -------------------------------
+
+    def test_battery_13v0(self):
+        """Byte 11 = 0x82 = 130 -> 13.0 V (confirmed by @atillack)."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['battery_08']
+        self.assertAlmostEqual(svc['/Dc/0/Voltage'], 13.0, places=1)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    # -- Synthetic: edge cases -------------------------------------------
+
+    def test_tank_with_capacity(self):
+        """Synthetic: slot 0 at 40%, capacity 0.3 m3 -> remaining 0.12."""
+        self.dev._role_services['tank_00']['Capacity'] = 0.3
+
+        payload = bytearray(BTP7_CAPTURE)
+        payload[3] = 40
+        self.dev.handle_manufacturer_data(bytes(payload))
+
+        svc = self.dev._role_services['tank_00']
+        self.assertEqual(svc['Level'], 40)
+        self.assertAlmostEqual(svc['Remaining'], 0.12, places=3)
+
+    def test_all_tanks_100pct(self):
+        """Synthetic: all 8 tanks at exactly 100%."""
+        payload = bytearray(14)
+        payload[0:3] = b'\x91\x04\x00'
+        for i in range(8):
+            payload[3 + i] = 100
+        payload[11] = 130
+
+        self.dev.handle_manufacturer_data(bytes(payload))
+
+        for slot in range(8):
+            svc = self.dev._role_services[f'tank_{slot:02d}']
+            self.assertEqual(svc['Level'], 100,
+                             f'slot {slot} should be 100%')
+
+    def test_battery_low_voltage(self):
+        """Synthetic: byte 11 = 110 -> 11.0 V."""
+        payload = bytearray(BTP7_CAPTURE)
+        payload[11] = 110
+        self.dev.handle_manufacturer_data(bytes(payload))
+
+        svc = self.dev._role_services['battery_08']
+        self.assertAlmostEqual(svc['/Dc/0/Voltage'], 11.0, places=1)
+
+    def test_battery_disabled_not_updated(self):
+        """Battery slot disabled -> no voltage update."""
+        self.dev._is_indexed_role_enabled = lambda rt, idx: rt == 'tank'
+
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['battery_08']
+        self.assertNotIn('/Dc/0/Voltage', svc)
+        self.assertFalse(svc.connected)
+
+    def test_short_payload_battery_safe(self):
+        """11-byte payload: tanks update, battery skipped (< 12 bytes)."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE[:11])
+
+        svc = self.dev._role_services['battery_08']
+        self.assertNotIn('/Dc/0/Voltage', svc)
+
+
+# ===================================================================
+# Sensor mapping consistency
+# ===================================================================
+
+class TestSensorMappings(unittest.TestCase):
+
+    def test_btp3_sensor_count(self):
+        self.assertEqual(len(BleDeviceSeeLevelBTP3.SENSORS), 14)
+
+    def test_btp3_all_sensors_have_role(self):
+        for num, (name, role_type, _) in BleDeviceSeeLevelBTP3.SENSORS.items():
+            self.assertIn(role_type, ('tank', 'temperature', 'battery'),
+                          f'sensor {num} ({name}) has unexpected role {role_type!r}')
+
+    def test_btp3_battery_is_sensor_13(self):
+        name, role_type, _ = BleDeviceSeeLevelBTP3.SENSORS[13]
+        self.assertEqual(role_type, 'battery')
+
+    def test_btp7_tank_slot_count(self):
+        self.assertEqual(len(BleDeviceSeeLevelBTP7.TANK_SLOTS), 8)
+
+    def test_btp7_roles_include_battery(self):
+        self.assertIn('battery', BleDeviceSeeLevelBTP7.ROLES)
+
+    def test_btp3_roles_include_all_three(self):
+        for role in ('tank', 'temperature', 'battery'):
+            self.assertIn(role, BleDeviceSeeLevelBTP3.ROLES)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -106,7 +106,38 @@ BTP7_CAPTURE = bytes.fromhex('9104001900006e6e6e6e6e820000')
 # ===================================================================
 
 class _NullRole:
-    """Stub role whose update_data is a no-op."""
+    """Stub role whose update_data is a no-op and has no alarms."""
+    info = {'alarms': []}
+
+    def update_data(self, role_service, sensor_data):
+        pass
+
+
+def _get_alarm_low_state(role_service) -> int:
+    if role_service['/Alarms/Low/Enable']:
+        alarm_state = bool(role_service['/Alarms/Low/State'])
+        threshold = role_service[f"/Alarms/Low/{'Restore' if alarm_state else 'Active'}"]
+        return int(float(role_service['Level']) < threshold)
+    return 0
+
+
+def _get_alarm_high_state(role_service) -> int:
+    if role_service['/Alarms/High/Enable']:
+        alarm_state = bool(role_service['/Alarms/High/State'])
+        threshold = role_service[f"/Alarms/High/{'Restore' if alarm_state else 'Active'}"]
+        return int(float(role_service['Level']) > threshold)
+    return 0
+
+
+class _MockTankRole:
+    """Stub tank role with framework alarm definitions."""
+    info = {
+        'alarms': [
+            {'name': '/Alarms/High/State', 'update': _get_alarm_high_state},
+            {'name': '/Alarms/Low/State', 'update': _get_alarm_low_state},
+        ]
+    }
+
     def update_data(self, role_service, sensor_data):
         pass
 
@@ -124,6 +155,10 @@ class MockRoleService(dict):
 
     def disconnect(self):
         self.connected = False
+
+    def update_alarm(self, alarm: dict):
+        alarm_state = alarm['update'](self)
+        self[alarm['name']] = alarm_state
 
     def get_dev_id(self):
         return 'test_dev'
@@ -278,17 +313,105 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
         self.assertEqual(svc['Status'], 0)
         self.assertTrue(svc.connected)
 
-    # -- Real capture: alarm byte ----------------------------------------
+    # -- Framework alarm evaluation ---------------------------------------
 
-    def test_alarm_byte_zero_from_real_capture(self):
-        """Real capture: all captured payloads have alarm byte '0' (0x30)."""
+    def test_framework_alarm_low_disabled(self):
+        """Framework alarms disabled -> /Alarms/Low/State stays 0."""
         svc = self._enable_sensor('tank', 0, {
-            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 0, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
         self._patch_enabled()
 
         self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
 
         self.assertEqual(svc['/Alarms/Low/State'], 0)
+
+    def test_framework_alarm_low_triggered(self):
+        """Tank at 5% with low alarm enabled (Active=10) -> alarm fires."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 1, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00  50000000')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 1)
+
+    def test_framework_alarm_low_not_triggered(self):
+        """Tank at 50% with low alarm enabled (Active=10) -> no alarm."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 1, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 500000000')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 0)
+
+    def test_framework_alarm_high_triggered(self):
+        """Tank at 95% with high alarm enabled (Active=90) -> alarm fires."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 0, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 1, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 950000000')
+
+        self.assertEqual(svc['/Alarms/High/State'], 1)
+
+    def test_framework_alarm_hysteresis(self):
+        """Alarm active: level must rise above Restore (15) to clear."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 1, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 1,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 120000000')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 1,
+                         "12% is below Restore(15), alarm should stay active")
+
+    def test_hardware_alarm_byte_not_used(self):
+        """Hardware alarm byte '3' no longer sets /Alarms/Low/State directly."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 0, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 100000003')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 0,
+                         "alarms disabled, hw byte should not override")
 
     # -- Synthetic: cases not covered by real hardware -------------------
 
@@ -324,15 +447,15 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
 
         self.assertEqual(svc['Level'], 100)
 
-    def test_alarm_nonzero(self):
-        """Synthetic: alarm byte '3' -> low alarm active."""
+    def test_alarm_null_role_no_crash(self):
+        """Tank with _NullRole (no alarms defined) -> no crash."""
         svc = self._enable_sensor('tank', 0, {
             'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
         self._patch_enabled()
 
-        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 100000003')
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 500000000')
 
-        self.assertEqual(svc['/Alarms/Low/State'], 1)
+        self.assertEqual(svc['Level'], 50)
 
     def test_temperature_72f(self):
         """Synthetic: sensor 7 (Temp), value '072' (72 degF) -> 22.2 degC."""
@@ -560,6 +683,38 @@ class TestBTP7HandleManufacturerData(unittest.TestCase):
         self.assertAlmostEqual(svc['/Dc/0/Voltage'], 13.0, places=1)
         self.assertEqual(svc['Status'], 0)
         self.assertTrue(svc.connected)
+
+    # -- Framework alarm evaluation (BTP7) --------------------------------
+
+    def test_framework_alarm_low_btp7(self):
+        """BTP7: Fresh at 25% with low alarm enabled (Active=30) -> alarm fires."""
+        svc = self.dev._role_services['tank_00']
+        svc.update({
+            '/Alarms/Low/Enable': 1, '/Alarms/Low/Active': 30,
+            '/Alarms/Low/Restore': 35, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        self.assertEqual(svc['/Alarms/Low/State'], 1)
+
+    def test_framework_alarm_disabled_btp7(self):
+        """BTP7: Fresh at 25% with alarms disabled -> no alarm."""
+        svc = self.dev._role_services['tank_00']
+        svc.update({
+            '/Alarms/Low/Enable': 0, '/Alarms/Low/Active': 30,
+            '/Alarms/Low/Restore': 35, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        self.assertEqual(svc['/Alarms/Low/State'], 0)
 
     # -- Synthetic: edge cases -------------------------------------------
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -245,16 +245,21 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
 
     # -- Real BTP3 capture: OPN (disconnected) ---------------------------
 
-    def test_lpg_opn_skipped(self):
-        """Real capture: sensor 3 (LPG), value 'OPN' -> no update."""
-        svc = self._enable_sensor('tank', 3, {
-            'FluidType': 8, 'Capacity': 0.0, 'Status': 0})
+    def test_lpg_opn_no_service_created(self):
+        """Real capture: sensor 3 (LPG), value 'OPN' -> service never created."""
         self._patch_enabled()
+        created = {}
 
+        def mock_create(role_type, index, device_name=None, config=None):
+            svc = _mock_create_service(self.dev, role_type, index,
+                                       device_name=device_name, defaults={})
+            created[f'{role_type}_{index:02d}'] = svc
+            return svc
+
+        self.dev._create_indexed_role_service = mock_create
         self.dev.handle_manufacturer_data(BTP3_LPG_OPEN)
 
-        self.assertNotIn('Level', svc)
-        self.assertFalse(svc.connected)
+        self.assertNotIn('tank_03', created)
 
     # -- Real BTP3 capture: battery voltage ------------------------------
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -105,12 +105,19 @@ BTP7_CAPTURE = bytes.fromhex('9104001900006e6e6e6e6e820000')
 # Helpers
 # ===================================================================
 
+class _NullRole:
+    """Stub role whose update_data is a no-op."""
+    def update_data(self, role_service, sensor_data):
+        pass
+
+
 class MockRoleService(dict):
     """Dict-like stand-in for DbusRoleService (no D-Bus required)."""
 
     def __init__(self, defaults=None):
         super().__init__(defaults or {})
         self.connected = False
+        self.ble_role = _NullRole()
 
     def connect(self):
         self.connected = True
@@ -346,6 +353,23 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
         self.dev.handle_manufacturer_data(b'\x8d\x95i\x070320000000')
 
         self.assertAlmostEqual(svc['Temperature'], 0.0, places=1)
+
+    def test_temperature_offset_applied(self):
+        """Synthetic: temperature offset +2.5 is applied via role update_data."""
+        svc = self._enable_sensor('temperature', 7, {'Status': 0, 'Offset': 2.5})
+        self._patch_enabled()
+
+        class OffsetRole:
+            def update_data(self, role_service, sensor_data):
+                offset = role_service.get('Offset', 0)
+                if offset and 'Temperature' in sensor_data:
+                    sensor_data['Temperature'] = sensor_data['Temperature'] + offset
+
+        svc.ble_role = OffsetRole()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x070720000000')
+
+        self.assertAlmostEqual(svc['Temperature'], 24.7, places=1)
 
     def test_battery_low_voltage(self):
         """Synthetic: sensor 13, value '108' -> 10.8 V."""

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_role_tank.py
@@ -153,6 +153,20 @@ class TestBleRoleTank(unittest.TestCase):
         self.dbus_role_service['Level'] = 16
         self.assertEqual(self.tank.get_alarm_low_state(self.dbus_role_service), 0)
 
+    def test_fluid_type_default_from_config(self):
+        """Config fluid_type sets the FluidType setting default."""
+        tank = BleRoleTank(config={'fluid_type': 5})
+        fluid_setting = next(
+            s for s in tank.info['settings'] if s['name'] == 'FluidType')
+        self.assertEqual(fluid_setting['props']['def'], 5)
+
+    def test_fluid_type_default_without_config(self):
+        """No fluid_type in config leaves FluidType default at 0."""
+        tank = BleRoleTank(config={})
+        fluid_setting = next(
+            s for s in tank.info['settings'] if s['name'] == 'FluidType')
+        self.assertEqual(fluid_setting['props']['def'], 0)
+
     def test_topdown_behavior(self):
         topdown = BleRoleTank(config={'flags': ['TANK_FLAG_TOPDOWN']})
         topdown._shape_map = [(0, 0), (1.0, 1.0)]

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_role_tank.py
@@ -153,6 +153,33 @@ class TestBleRoleTank(unittest.TestCase):
         self.dbus_role_service['Level'] = 16
         self.assertEqual(self.tank.get_alarm_low_state(self.dbus_role_service), 0)
 
+    def test_capacity_default_is_0_2(self):
+        """Capacity defaults to 0.2 m³ — a placeholder until the user configures it."""
+        tank = BleRoleTank(config={})
+        cap_setting = next(
+            s for s in tank.info['settings'] if s['name'] == 'Capacity')
+        self.assertEqual(cap_setting['props']['def'], 0.2)
+
+    def test_level_is_percentage_regardless_of_capacity(self):
+        """Level is always 0-100% independent of the Capacity value."""
+        self.tank._shape_map = []
+        for capacity in (0.2, 1.0, 53.0, 200.0):
+            level, remaining, status = self.tank._compute_level(
+                rawValue=50.0, empty=0.0, full=100.0, capacity=capacity)
+            self.assertEqual(level, 50, f"Level should be 50% at capacity={capacity}")
+            self.assertEqual(status, 0)
+
+    def test_remaining_scales_with_capacity(self):
+        """Remaining volume is proportional to capacity — meaningless until user sets it."""
+        self.tank._shape_map = []
+        level, remaining, _ = self.tank._compute_level(
+            rawValue=50.0, empty=0.0, full=100.0, capacity=0.2)
+        self.assertAlmostEqual(remaining, 0.1, places=6)
+
+        level, remaining, _ = self.tank._compute_level(
+            rawValue=50.0, empty=0.0, full=100.0, capacity=100.0)
+        self.assertAlmostEqual(remaining, 50.0, places=6)
+
     def test_fluid_type_default_from_config(self):
         """Config fluid_type sets the FluidType setting default."""
         tank = BleRoleTank(config={'fluid_type': 5})

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_role_tank.py
@@ -27,10 +27,12 @@ class TestBleRoleTank(unittest.TestCase):
             '/Alarms/High/Enable': 0,
             '/Alarms/High/Active': 90,
             '/Alarms/High/Restore': 80,
+            '/Alarms/High/Delay': 0,
             '/Alarms/High/State': 0,
             '/Alarms/Low/Enable': 0,
             '/Alarms/Low/Active': 10,
             '/Alarms/Low/Restore': 15,
+            '/Alarms/Low/Delay': 0,
             '/Alarms/Low/State': 0,
             'Level': 0.0,
             'Remaining': 0.0,
@@ -164,3 +166,58 @@ class TestBleRoleTank(unittest.TestCase):
         self.assertEqual(level, 50)
         self.assertAlmostEqual(remaining, 50.0, places=6)
         self.assertEqual(status, 0)
+
+    def test_alarm_delay_suppresses_immediate_trigger(self):
+        """With delay=10s, first threshold crossing should not fire alarm."""
+        self.dbus_role_service['Level'] = 5
+        self.dbus_role_service['/Alarms/Low/Enable'] = 1
+        self.dbus_role_service['/Alarms/Low/Delay'] = 10
+        self.assertEqual(self.tank.get_alarm_low_state(self.dbus_role_service), 0)
+
+    def test_alarm_delay_fires_after_elapsed(self):
+        """After delay seconds have elapsed, alarm should fire."""
+        import time
+        self.dbus_role_service['Level'] = 5
+        self.dbus_role_service['/Alarms/Low/Enable'] = 1
+        self.dbus_role_service['/Alarms/Low/Delay'] = 0
+        self.assertEqual(self.tank.get_alarm_low_state(self.dbus_role_service), 1)
+
+        tank2 = BleRoleTank(config={'flags': []})
+        tank2.check_configuration()
+        svc_id = id(self.dbus_role_service)
+        tank2._alarm_pending[f'low_{svc_id}'] = time.monotonic() - 15
+        self.dbus_role_service['/Alarms/Low/Delay'] = 10
+        self.assertEqual(tank2.get_alarm_low_state(self.dbus_role_service), 1)
+
+    def test_alarm_delay_clears_on_recovery(self):
+        """If level recovers before delay expires, pending timer is cleared."""
+        import time
+        self.dbus_role_service['Level'] = 5
+        self.dbus_role_service['/Alarms/Low/Enable'] = 1
+        self.dbus_role_service['/Alarms/Low/Delay'] = 30
+        self.tank.get_alarm_low_state(self.dbus_role_service)
+        svc_id = id(self.dbus_role_service)
+        self.assertIn(f'low_{svc_id}', self.tank._alarm_pending)
+
+        self.dbus_role_service['Level'] = 50
+        self.tank.get_alarm_low_state(self.dbus_role_service)
+        self.assertNotIn(f'low_{svc_id}', self.tank._alarm_pending)
+
+    def test_alarm_delay_zero_fires_immediately(self):
+        """Delay=0 means alarm fires on first threshold crossing."""
+        self.dbus_role_service['Level'] = 95
+        self.dbus_role_service['/Alarms/High/Enable'] = 1
+        self.dbus_role_service['/Alarms/High/Delay'] = 0
+        self.assertEqual(self.tank.get_alarm_high_state(self.dbus_role_service), 1)
+
+    def test_alarm_delay_settings_in_role_info(self):
+        """BleRoleTank info includes /Alarms/High/Delay and /Alarms/Low/Delay settings."""
+        setting_names = [s['name'] for s in self.tank.info['settings']]
+        self.assertIn('/Alarms/High/Delay', setting_names)
+        self.assertIn('/Alarms/Low/Delay', setting_names)
+
+    def test_alarm_delay_defaults(self):
+        """Default delay values match GUI mock conventions."""
+        settings_by_name = {s['name']: s for s in self.tank.info['settings']}
+        self.assertEqual(settings_by_name['/Alarms/High/Delay']['props']['def'], 5)
+        self.assertEqual(settings_by_name['/Alarms/Low/Delay']['props']['def'], 30)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_create_indexed_role_service_guard.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_create_indexed_role_service_guard.py
@@ -1,0 +1,194 @@
+"""
+Pin the contract that ``BleDevice._create_indexed_role_service``
+**never mutates** ``self.info['dev_id']``.
+
+The previous design temporarily wrote the indexed dev id into
+``self.info['dev_id']`` so that ``DbusRoleService.__init__`` would pick
+it up as a side channel.  Any exception during role-service init left
+the field corrupt; the next advertisement re-read the corrupt value as
+its "base" and appended yet another ``_NN`` — on a multi-sensor device
+broadcasting many indices a second (e.g. SeeLevel BTP3) the dev id
+grew unboundedly, registering hundreds of bloated paths in
+``com.victronenergy.settings``.
+
+The proper fix removes the mutation entirely.  ``DbusRoleService``
+takes the indexed dev id as an explicit constructor parameter;
+``self.info['dev_id']`` is only ever read, never written.  These tests
+assert that contract directly.
+"""
+
+import importlib.util
+import logging
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext', 'velib_python'))
+
+
+# Stub D-Bus / vedbus / inner services for off-device import.
+def _ensure_stub(name: str, attrs: dict):
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(sys.modules[name], key, value)
+
+
+_ensure_stub('dbus', {
+    'SystemBus': lambda **kw: MagicMock(),
+    'SessionBus': lambda **kw: MagicMock(),
+    'Interface': lambda *a, **kw: MagicMock(),
+    'Bus': type('Bus', (), {}),
+    'Int64': int,
+    'String': str,
+})
+_ensure_stub('dbus.bus', {'BusConnection': type('BusConnection', (), {})})
+sys.modules['dbus'].bus = sys.modules['dbus.bus']
+_ensure_stub('vedbus', {
+    'VeDbusService': MagicMock,
+    'VeDbusItemImport': MagicMock,
+    'VeDbusItemExport': MagicMock,
+})
+_ensure_stub('settingsdevice', {})
+_ensure_stub('dbus_settings_service', {
+    'DbusSettingsService': MagicMock,
+})
+_ensure_stub('dbus_ble_service', {
+    'DbusBleService': type('DbusBleService', (), {
+        'get': staticmethod(lambda: MagicMock()),
+    }),
+})
+_ensure_stub('dbus_role_service', {
+    'DbusRoleService': MagicMock,
+})
+
+
+_ble_device_path = os.path.join(os.path.dirname(__file__), '..', 'ble_device.py')
+_spec = importlib.util.spec_from_file_location('_real_ble_device', _ble_device_path)
+_real_ble_device = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_real_ble_device)
+BleDevice = _real_ble_device.BleDevice
+
+
+# Bypass the heavy ``__init__`` of BleDevice — we want a direct test of
+# ``_create_indexed_role_service`` and need to control ``self.info``
+# without dragging in the full settings / D-Bus init.
+def _make_device(dev_id: str = 'seelevel_btp3_00a0508d9569') -> BleDevice:
+    dev = BleDevice.__new__(BleDevice)
+    dev.info = {
+        'dev_id': dev_id,
+        'dev_prefix': 'seelevel_btp3',
+        'dev_mac': '00a0508d9569',
+        'roles': {},
+        'settings': [],
+        'alarms': [],
+        'product_id': 0,
+        'product_name': '',
+        'device_name': '',
+        'firmware_version': '',
+        'hardware_version': '',
+        'manufacturer_id': 0,
+    }
+    dev._role_services = {}
+    dev._plog = '[test]'
+    return dev
+
+
+class DevIdIsNeverMutated(unittest.TestCase):
+
+    def test_dev_id_unchanged_on_role_service_construction_failure(self):
+        dev = _make_device()
+        original = dev.info['dev_id']
+
+        with patch.object(_real_ble_device, 'BleRole') as mock_role_cls:
+            mock_role_cls.get_class.return_value = MagicMock()
+            with patch.object(_real_ble_device, 'DbusRoleService',
+                              side_effect=RuntimeError('AddMatch budget exhausted')):
+                result = dev._create_indexed_role_service('tank', 0)
+
+        self.assertIsNone(result, "should return None on failure")
+        self.assertEqual(dev.info['dev_id'], original,
+            f"dev_id must not be mutated; got {dev.info['dev_id']!r}")
+
+    def test_dev_id_unchanged_on_load_settings_failure(self):
+        dev = _make_device()
+        original = dev.info['dev_id']
+
+        fake_role_service = MagicMock()
+        fake_role_service.load_settings.side_effect = KeyError('min')
+
+        with patch.object(_real_ble_device, 'BleRole') as mock_role_cls:
+            mock_role_cls.get_class.return_value = MagicMock()
+            with patch.object(_real_ble_device, 'DbusRoleService',
+                              return_value=fake_role_service):
+                result = dev._create_indexed_role_service('tank', 1)
+
+        self.assertIsNone(result)
+        self.assertEqual(dev.info['dev_id'], original)
+
+    def test_repeated_failures_do_not_compound_corruption(self):
+        """The pre-refactor bug: each failed creation read the already-
+        mutated ``dev_id`` and appended another ``_NN``.  After 50 cycles
+        through the SeeLevel sensor sequence (4 indices each) the dev id
+        grew by ~600 chars.  With the refactor the field is never
+        written, so even 200 forced failures cannot corrupt it."""
+        dev = _make_device()
+        original = dev.info['dev_id']
+
+        with patch.object(_real_ble_device, 'BleRole') as mock_role_cls:
+            mock_role_cls.get_class.return_value = MagicMock()
+            with patch.object(_real_ble_device, 'DbusRoleService',
+                              side_effect=RuntimeError('forced failure')):
+                for _ in range(50):
+                    for idx in (0, 1, 2, 13):
+                        dev._create_indexed_role_service('tank', idx)
+
+        self.assertEqual(dev.info['dev_id'], original,
+            f"dev_id grew under repeated failure; got len={len(dev.info['dev_id'])}: "
+            f"{dev.info['dev_id'][:80]}...")
+
+    def test_dev_id_unchanged_on_success(self):
+        """Even the happy path must not touch ``self.info['dev_id']``."""
+        dev = _make_device()
+        original = dev.info['dev_id']
+
+        with patch.object(_real_ble_device, 'BleRole') as mock_role_cls:
+            mock_role_cls.get_class.return_value = MagicMock()
+            with patch.object(_real_ble_device, 'DbusRoleService',
+                              return_value=MagicMock()):
+                result = dev._create_indexed_role_service('tank', 0)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(dev.info['dev_id'], original)
+
+
+class IndexedDevIdPassedToConstructor(unittest.TestCase):
+    """Verify the constructor receives the indexed dev id as an
+    explicit ``dev_id=`` keyword, rather than reading it back from
+    ``ble_device.info['dev_id']`` (which would re-introduce the
+    side-channel coupling)."""
+
+    def test_constructor_called_with_indexed_dev_id_keyword(self):
+        dev = _make_device(dev_id='seelevel_btp3_00a0508d9569')
+
+        with patch.object(_real_ble_device, 'BleRole') as mock_role_cls:
+            mock_role_cls.get_class.return_value = MagicMock()
+            with patch.object(_real_ble_device, 'DbusRoleService',
+                              return_value=MagicMock()) as ctor:
+                dev._create_indexed_role_service('tank', 7)
+
+        ctor.assert_called_once()
+        kwargs = ctor.call_args.kwargs
+        self.assertIn('dev_id', kwargs,
+            f"DbusRoleService must be called with explicit dev_id kwarg; "
+            f"got args={ctor.call_args.args}, kwargs={kwargs}")
+        self.assertEqual(kwargs['dev_id'], 'seelevel_btp3_00a0508d9569_07')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds complete support for the **Garnet SeeLevel 709-BT** series of BLE tank/temperature/battery monitors, including a small set of framework extensions to enable multi-sensor devices.

### Framework extensions (commit 1)

- **`CUSTOM_PARSING` flag** on `BleDevice`: subclasses that override `handle_manufacturer_data()` and don't use the register-based parsing pipeline can set this to `True` to skip the "regs must be non-empty" validation.
- **`_create_indexed_role_service()`**: creates uniquely-keyed D-Bus services for each sensor slot (e.g. `com.victronenergy.tank.seelevel_mac_00`), enabling devices that expose multiple instances of the same role type.
- **`_is_indexed_role_enabled()`**: checks if a specific indexed slot is enabled in the GUI settings.
- **`fluid_type` config key** on `BleRoleTank`: sets the `FluidType` setting default at service creation time (e.g. Fresh water, Wash water, Toilet water).
- **`custom_name` config key** on all role classes: sets the `CustomName` setting default at service creation time so sensors appear with meaningful names without user configuration.
- **Alarm delay settings** on `BleRoleTank`: `/Alarms/High/Delay` and `/Alarms/Low/Delay` (seconds) with `_check_alarm_delay()` logic — alarms only fire after the level has been past the threshold continuously for the configured duration, preventing spurious alerts from momentary level fluctuations.
- **Bug fix** in `dbus_role_service.py`: `KeyError` when settings lack `min`/`max` properties (use `.get()` with default 0).
- **Bug fix** in `ble_role_tank.py`: crash in `_compute_level` when `shape_map` is `None` (guard the `len()` call).
- **Bug fix** in `ble_role_tank.py`: crash in `_tank_capacity_changed` when `RawValue` is `None` before first advertisement.
- **Bug fix** in role subclasses (`BleRoleBattery`, `BleRoleDigitalInput`, `BleRoleMeteo`, `BleRoleMovement`, `BleRoleTemperature`): `super().__init__()` was not passing `config`, causing `custom_name` to be silently dropped.

### SeeLevel implementation (commits 2+)

Two hardware variants are supported, distinguished by BLE manufacturer ID:

| Variant | Mfg ID | Sensors | Lifecycle |
|---------|--------|---------|-----------|
| **BTP3** (Cypress) | 305 (0x0131) | 7 tanks, 4 temp, 2 chemical, 1 battery — one per advertisement | Lazy: services created on first advert |
| **BTP7** | 3264 (0x0CC0) | 8 tanks + 1 battery in a single 14-byte advertisement | Eager: all services created at init |

**New files:**
- `seelevel_common.py` — shared base class with full protocol reference documentation (packet formats, sensor numbers, error codes, unit conversions, D-Bus mappings)
- `ble_device_seelevel_btp3.py` — BTP3 protocol implementation
- `ble_device_seelevel_btp7.py` — BTP7 protocol implementation
- `ble_role_battery.py` — battery voltage monitor role class (`com.victronenergy.battery`)
- `tests/test_ble_device_seelevel.py` — 60+ unit tests

**Design decisions:**
- Tank capacities default to 0.2 m³ (framework default) until the user configures them. Since SeeLevel only reports percentages, volume readings are meaningless until the user enters their actual tank size.
- FluidType defaults are set per-slot from the SeeLevel spec (Fresh water, Wash water, Toilet water, LPG) so tanks appear correctly labeled without any user configuration.
- CustomName defaults are set so sensors appear with meaningful names (e.g. "Fresh Water", "SeeLevel Voltage") immediately.
- Battery voltage is exposed as a `battery` role, defaulting to enabled. Users can toggle it off from the GUI.
- BTP3 `OPN` (open/disconnected) sensors are silently skipped — no D-Bus service is created until a sensor is connected.
- BTP3 temperature sensors convert Fahrenheit → Celsius.

## Test plan

- [x] 60+ unit tests pass locally (`pytest tests/test_ble_device_seelevel.py tests/test_ble_role_tank.py`)
- [x] Tests use real BLE captures from a Cerbo GX (BTP3, 2025 Airstream Flying Cloud) and btmon (BTP7, from [victron-seelevel-python#1](https://github.com/TechBlueprints/victron-seelevel-python/issues/1))
- [x] Deployed and verified on production Cerbo GX — all tanks and battery voltage display correctly in Venus OS GUI
- [x] D-Bus services appear correctly: `com.victronenergy.tank.seelevel_*`, `com.victronenergy.battery.seelevel_*`
- [x] Tank enable/disable toggle works from GUI
- [x] FluidType and CustomName defaults appear correctly without user configuration
- [x] Alarm delay settings appear in GUI and prevent spurious alerts

## References

- Protocol decode: https://github.com/custom-components/ble_monitor/issues/1181
- BTP7 btmon capture: https://github.com/TechBlueprints/victron-seelevel-python/issues/1
- Original Python implementation: https://github.com/TechBlueprints/victron-seelevel-python