### PR TITLE
Add alarm delay setting to BleRoleTank

### DIFF
--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
@@ -1,6 +1,7 @@
 from ble_role import BleRole
 from ve_types import *
 import logging
+import time
 
 
 class BleRoleTank(BleRole):
@@ -65,6 +66,7 @@ class BleRoleTank(BleRole):
         flags = config.get('flags', []) if config is not None else []
         self._is_topdown: bool = 'TANK_FLAG_TOPDOWN' in flags
         self._shape_map = None
+        self._alarm_pending: dict[str, float | None] = {}
 
         self.info.update(
             {
@@ -136,6 +138,15 @@ class BleRoleTank(BleRole):
                         }
                     },
                     {
+                        'name': '/Alarms/High/Delay',
+                        'props': {
+                            'type': VE_SN32,
+                            'def': 5,
+                            'min': 0,
+                            'max': 100
+                        }
+                    },
+                    {
                         'name': '/Alarms/Low/Enable',
                         'props': {
                             'type': VE_UN8,
@@ -162,6 +173,15 @@ class BleRoleTank(BleRole):
                             'max': 100
                         }
                     },
+                    {
+                        'name': '/Alarms/Low/Delay',
+                        'props': {
+                            'type': VE_SN32,
+                            'def': 30,
+                            'min': 0,
+                            'max': 100
+                        }
+                    },
                 ],
                 'alarms': [
                     {
@@ -176,6 +196,29 @@ class BleRoleTank(BleRole):
             }
         )
 
+    def _check_alarm_delay(self, key: str, triggered: bool, delay: int) -> bool:
+        """
+        Apply alarm delay logic. Returns True when the alarm should be active.
+
+        When `triggered` is True (level past threshold) and `delay` > 0, the
+        alarm only activates after the level has been past the threshold for
+        `delay` continuous seconds.  If the level recovers before the delay
+        expires, the pending timer is cleared.
+        """
+        now = time.monotonic()
+        if triggered:
+            if delay <= 0:
+                self._alarm_pending.pop(key, None)
+                return True
+            pending_since = self._alarm_pending.get(key)
+            if pending_since is None:
+                self._alarm_pending[key] = now
+                return False
+            return (now - pending_since) >= delay
+        else:
+            self._alarm_pending.pop(key, None)
+            return False
+
     def get_alarm_high_state(self, role_service) -> int:
         """
         Default method to compute tank high level alarm. Can be overridden by overloading info['alarms'] entries in device class.
@@ -185,7 +228,12 @@ class BleRoleTank(BleRole):
             alarm_state = bool(role_service['/Alarms/High/State'])
             alarm_threshold = role_service[f"/Alarms/High/{'Restore' if alarm_state else 'Active'}"]
             tank_level = float(role_service['Level'])
-            return int(tank_level > alarm_threshold)
+            triggered = tank_level > alarm_threshold
+            if alarm_state:
+                return int(triggered)
+            delay = int(role_service['/Alarms/High/Delay'] or 0)
+            svc_id = id(role_service)
+            return int(self._check_alarm_delay(f'high_{svc_id}', triggered, delay))
         else:
             return 0
 
@@ -198,7 +246,12 @@ class BleRoleTank(BleRole):
             alarm_state = bool(role_service['/Alarms/Low/State'])
             alarm_threshold = role_service[f"/Alarms/Low/{'Restore' if alarm_state else 'Active'}"]
             tank_level = float(role_service['Level'])
-            return int(tank_level < alarm_threshold)
+            triggered = tank_level < alarm_threshold
+            if alarm_state:
+                return int(triggered)
+            delay = int(role_service['/Alarms/Low/Delay'] or 0)
+            svc_id = id(role_service)
+            return int(self._check_alarm_delay(f'low_{svc_id}', triggered, delay))
         else:
             return 0
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_role_tank.py
@@ -27,10 +27,12 @@ class TestBleRoleTank(unittest.TestCase):
             '/Alarms/High/Enable': 0,
             '/Alarms/High/Active': 90,
             '/Alarms/High/Restore': 80,
+            '/Alarms/High/Delay': 0,
             '/Alarms/High/State': 0,
             '/Alarms/Low/Enable': 0,
             '/Alarms/Low/Active': 10,
             '/Alarms/Low/Restore': 15,
+            '/Alarms/Low/Delay': 0,
             '/Alarms/Low/State': 0,
             'Level': 0.0,
             'Remaining': 0.0,
@@ -164,3 +166,58 @@ class TestBleRoleTank(unittest.TestCase):
         self.assertEqual(level, 50)
         self.assertAlmostEqual(remaining, 50.0, places=6)
         self.assertEqual(status, 0)
+
+    def test_alarm_delay_suppresses_immediate_trigger(self):
+        """With delay=10s, first threshold crossing should not fire alarm."""
+        self.dbus_role_service['Level'] = 5
+        self.dbus_role_service['/Alarms/Low/Enable'] = 1
+        self.dbus_role_service['/Alarms/Low/Delay'] = 10
+        self.assertEqual(self.tank.get_alarm_low_state(self.dbus_role_service), 0)
+
+    def test_alarm_delay_fires_after_elapsed(self):
+        """After delay seconds have elapsed, alarm should fire."""
+        import time
+        self.dbus_role_service['Level'] = 5
+        self.dbus_role_service['/Alarms/Low/Enable'] = 1
+        self.dbus_role_service['/Alarms/Low/Delay'] = 0
+        self.assertEqual(self.tank.get_alarm_low_state(self.dbus_role_service), 1)
+
+        tank2 = BleRoleTank(config={'flags': []})
+        tank2.check_configuration()
+        svc_id = id(self.dbus_role_service)
+        tank2._alarm_pending[f'low_{svc_id}'] = time.monotonic() - 15
+        self.dbus_role_service['/Alarms/Low/Delay'] = 10
+        self.assertEqual(tank2.get_alarm_low_state(self.dbus_role_service), 1)
+
+    def test_alarm_delay_clears_on_recovery(self):
+        """If level recovers before delay expires, pending timer is cleared."""
+        import time
+        self.dbus_role_service['Level'] = 5
+        self.dbus_role_service['/Alarms/Low/Enable'] = 1
+        self.dbus_role_service['/Alarms/Low/Delay'] = 30
+        self.tank.get_alarm_low_state(self.dbus_role_service)
+        svc_id = id(self.dbus_role_service)
+        self.assertIn(f'low_{svc_id}', self.tank._alarm_pending)
+
+        self.dbus_role_service['Level'] = 50
+        self.tank.get_alarm_low_state(self.dbus_role_service)
+        self.assertNotIn(f'low_{svc_id}', self.tank._alarm_pending)
+
+    def test_alarm_delay_zero_fires_immediately(self):
+        """Delay=0 means alarm fires on first threshold crossing."""
+        self.dbus_role_service['Level'] = 95
+        self.dbus_role_service['/Alarms/High/Enable'] = 1
+        self.dbus_role_service['/Alarms/High/Delay'] = 0
+        self.assertEqual(self.tank.get_alarm_high_state(self.dbus_role_service), 1)
+
+    def test_alarm_delay_settings_in_role_info(self):
+        """BleRoleTank info includes /Alarms/High/Delay and /Alarms/Low/Delay settings."""
+        setting_names = [s['name'] for s in self.tank.info['settings']]
+        self.assertIn('/Alarms/High/Delay', setting_names)
+        self.assertIn('/Alarms/Low/Delay', setting_names)
+
+    def test_alarm_delay_defaults(self):
+        """Default delay values match GUI mock conventions."""
+        settings_by_name = {s['name']: s for s in self.tank.info['settings']}
+        self.assertEqual(settings_by_name['/Alarms/High/Delay']['props']['def'], 5)
+        self.assertEqual(settings_by_name['/Alarms/Low/Delay']['props']['def'], 30)


### PR DESCRIPTION
## Summary

- Adds `/Alarms/High/Delay` (default 5s) and `/Alarms/Low/Delay` (default 30s) settings to `BleRoleTank`, matching the D-Bus paths expected by the Venus OS GUI (`PageTankAlarm.qml`).
- Implements delay logic: when delay > 0, the alarm only activates after the tank level has been past the threshold for the configured number of continuous seconds. If the level recovers before the delay expires, the pending timer is cleared.
- Previously, the GUI would display a "Delay" row in the tank alarm setup page, but there was no backing D-Bus value -- the setting was silently ignored.

## Changes

- **`ble_role_tank.py`**: Added `/Alarms/High/Delay` and `/Alarms/Low/Delay` to the settings list. Added `_alarm_pending` dict and `_check_alarm_delay()` method. Updated `get_alarm_high_state()` and `get_alarm_low_state()` to apply delay before activating an alarm.
- **`tests/test_ble_role_tank.py`**: Added Delay keys to the test mock. Added 6 new tests covering delay suppression, elapsed firing, recovery clearing, zero-delay immediate firing, settings presence, and default values.

## Test plan

- [x] All 16 tank role tests pass locally (10 existing + 6 new)
- [x] All other role tests (temperature, movement) still pass
- [ ] Deploy to Cerbo GX and verify alarm delay behavior with real tanks
- [ ] Verify GUI shows and persists the Delay setting correctly