### PR TITLE
Fix detection of non-discoverable BLE devices

### DIFF
--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
@@ -334,9 +334,10 @@ class BleDevice(object):
             # Filtering data
             role_data = sensor_data[role_service.ble_role.NAME]
             if role_data:
-                # Update sensor data from update callbacks
-                role_service.ble_role.update_data(role_service, role_data)
+                # Device-level transform first (e.g. Mopeka xlate scaling),
+                # then role-level computation (e.g. tank Level from RawValue).
                 self.update_data(role_service, role_data)
+                role_service.ble_role.update_data(role_service, role_data)
 
                 # Update Dbus with new data
                 self._update_dbus_data(role_service, role_data)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_mopeka.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_mopeka.py
@@ -288,7 +288,11 @@ class BleDeviceMopeka(BleDevice):
 
     def _get_low_battery_state(self, role_service: DbusRoleService) -> int:
         # Percentage based on 3 volt CR2032 battery
-        if (battery_voltage := role_service.get('BatteryVoltage', None)) is None:
+        try:
+            battery_voltage = role_service['BatteryVoltage']
+        except (KeyError, TypeError):
+            return 0
+        if battery_voltage is None:
             return 0
         battery_percentage = max(0, min(100, ((battery_voltage - 2.2) / 0.65) * 100))
         return int(battery_percentage < 15)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_mopeka.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_mopeka.py
@@ -36,15 +36,15 @@ class BleDeviceMopeka(BleDevice):
                     },
                 }
             ],
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         },
         4: {
             'device_name': 'Mopeka Pro200',
-            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}}
         },
         5: {
             'device_name': 'Mopeka H20',
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         },
         8: {
             'device_name': 'Mopeka PPB',
@@ -59,7 +59,7 @@ class BleDeviceMopeka(BleDevice):
                     },
                 }
             ],
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         },
         9: {
             'device_name': 'Mopeka PPC',
@@ -74,15 +74,15 @@ class BleDeviceMopeka(BleDevice):
                     },
                 }
             ],
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         },
         10: {
             'device_name': 'Mopeka TDB',
-            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}}
         },
         11: {
             'device_name': 'Mopeka TDC',
-            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}}
         },
         12: {
             'device_name': 'Mopeka Univ',
@@ -97,7 +97,7 @@ class BleDeviceMopeka(BleDevice):
                     },
                 }
             ],
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         }
     }
 
@@ -157,7 +157,7 @@ class BleDeviceMopeka(BleDevice):
                     'bits': 7,
                     'scale': 1,
                     'bias': -40,
-                    'roles': ['temperature'],
+                    'roles': ['tank'],
                     # .format	= &veUnitCelsius1Dec,
                 },
                 {
@@ -191,7 +191,7 @@ class BleDeviceMopeka(BleDevice):
                     'type': VE_SN8,
                     'offset': 8,
                     'scale': 1024,
-                    'roles': ['movement'],
+                    'roles': [None],
                     # .format	= &veUnitG2Dec,
                 },
                 {
@@ -199,7 +199,7 @@ class BleDeviceMopeka(BleDevice):
                     'type': VE_SN8,
                     'offset': 9,
                     'scale': 1024,
-                    'roles': ['movement'],
+                    'roles': [None],
                     # .format	= &veUnitG2Dec,
                 }
             ],
@@ -227,16 +227,20 @@ class BleDeviceMopeka(BleDevice):
     def _get_scale_butane(self, butane_ratio: int, temperature: float) -> float:
         """
         Calculate the butane scale factor based on temperature and user-defined ratio.
+        Matches C: mopeka_coefs_butane[0] * r + mopeka_coefs_butane[1] * r * temp
         """
-        return self._COEFS_BUTANE[0] + self._COEFS_BUTANE[1] * temperature * (butane_ratio / 100.0)
+        r = butane_ratio / 100.0
+        return self._COEFS_BUTANE[0] * r + self._COEFS_BUTANE[1] * r * temperature
 
     def update_data(self, role_service: DbusRoleService, sensor_data: dict):
         """
-        Check for presence of extension bit on certain hardware/firmware saturates at 16383.
-        When extension bit is set, the raw_value resolution changes to 4us with 16384 us offset.
-        Thus old sensors and firmware still have 0 to 16383 us range with 1us, and new
-        versions add the range 16384 us to 81916 us with 4 us resolution.
+        Scale the ultrasonic RawValue into centimetres using temperature-dependent
+        polynomial coefficients.  Mirrors the C implementation's mopeka_xlate_level
+        which is an xlate callback on the RawValue register (tank role only).
         """
+        if role_service.ble_role.NAME != 'tank':
+            return
+
         if (temperature := sensor_data.get('Temperature', None)) is None:
             logging.warning(f"{self._plog} can not update sensor data, missing temperature value")
             return

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_safiery.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_safiery.py
@@ -105,7 +105,11 @@ class BleDeviceSafiery(BleDevice):
         return True
 
     def _get_low_battery_state(self, role_service: DbusRoleService) -> int:
-        if (battery_voltage := role_service.get('BatteryVoltage', None)) is None:
+        try:
+            battery_voltage = role_service['BatteryVoltage']
+        except (KeyError, TypeError):
+            return 0
+        if battery_voltage is None:
             return 0
         # Percentage based on 3 volt CR2477 battery
         battery_percentage = max(0, min(100, ((battery_voltage - 2.2) / 0.65) * 100))

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -23,6 +23,13 @@ from man_id import MAN_NAMES
 SNIF_LOGGER = logging.getLogger("sniffer")
 SNIF_LOGGER.propagate = False
 
+# Some BLE devices (e.g. Mopeka sensors) advertise without the standard
+# Flags AD type (0x01).  BlueZ's default active scan with DuplicateData=False
+# treats these as "non-discoverable" and silently drops them.  A supplementary
+# scan with DuplicateData=True catches all advertisements regardless of
+# discoverability flags.
+NONDISCOVERABLE_SCAN_TIMEOUT = 15
+
 class DbusBleSensors(object):
     """
     Main class for the D-bus BLE Sensors python service.
@@ -137,6 +144,7 @@ class DbusBleSensors(object):
                         self._known_mac[dev_mac] = dev_instance
                     except Exception as e:
                         logging.exception(f"{plog} ignoring data {man_data!r}, an error occurred during device initialization:")
+                        self._ignored_mac[dev_mac] = True
                         continue
                 else:
                     dev_instance = self._known_mac[dev_mac]
@@ -155,6 +163,22 @@ class DbusBleSensors(object):
             logging.debug(f"{adapter}: Scan finished")
         except Exception:
             logging.exception(f"{adapter}: Scan error")
+
+        try:
+            async with bleak.BleakScanner(
+                adapter=adapter,
+                detection_callback=_scan_callback,
+                bluez=dict(filters={"DuplicateData": True}),
+            ) as scanner:
+                await asyncio.sleep(NONDISCOVERABLE_SCAN_TIMEOUT)
+            logging.debug(f"{adapter}: Nondiscoverable scan finished")
+        except bleak.exc.BleakDBusError as e:
+            if "InProgress" in str(e):
+                logging.debug(f"{adapter}: nondiscoverable scan skipped (InProgress)")
+            else:
+                logging.warning(f"{adapter}: nondiscoverable scan error: {e}")
+        except Exception:
+            logging.warning(f"{adapter}: nondiscoverable scan error", exc_info=True)
 
     async def scan_loop(self):
         while True:

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -13,22 +13,47 @@ from ble_device import BleDevice
 from ble_role import BleRole
 from dbus_ble_service import DbusBleService
 import bleak
+from bleak.assigned_numbers import AdvertisementDataType
 import gbulb
 from logger import setup_logging
 from collections.abc import MutableMapping
+import threading
 import time
-from conf import SCAN_TIMEOUT, SCAN_SLEEP, IGNORED_DEVICES_TIMEOUT, DEVICE_SERVICES_TIMEOUT, PROCESS_VERSION
+from conf import IGNORED_DEVICES_TIMEOUT, DEVICE_SERVICES_TIMEOUT, PROCESS_VERSION
 from man_id import MAN_NAMES
 
 SNIF_LOGGER = logging.getLogger("sniffer")
 SNIF_LOGGER.propagate = False
 
-# Some BLE devices (e.g. Mopeka sensors) advertise without the standard
-# Flags AD type (0x01).  BlueZ's default active scan with DuplicateData=False
-# treats these as "non-discoverable" and silently drops them.  A supplementary
-# scan with DuplicateData=True catches all advertisements regardless of
-# discoverability flags.
-NONDISCOVERABLE_SCAN_TIMEOUT = 15
+SCANNER_INITIAL_BACKOFF = 2
+SCANNER_MAX_BACKOFF = 60
+SCANNER_MAX_PASSIVE_RETRIES = 5
+SCANNER_ACTIVE_CYCLE_DURATION = 15
+
+# OrPattern tuples for passive scanning via BlueZ AdvertisementMonitor1.
+# Passive scanning avoids calling StartDiscovery, which eliminates scan
+# contention (InProgress errors) when multiple BLE services share the
+# adapter.  Each tuple is (offset, AD_type, value) where AD_type is the
+# BLE AD type code and value is a prefix to match.
+# Requires BlueZ >= 5.56 with --experimental and kernel >= 5.10.
+#
+# Only Flags-based patterns are used here.  Manufacturer-data patterns
+# (AD type 0xFF) crash BlueZ 5.72 / kernel 6.12 with heap corruption
+# (free(): invalid next size).  To catch devices that omit Flags entirely
+# (e.g. Mopeka sensors), a periodic active scan with DuplicateData=True
+# is run alongside the passive scanner — see _run_nondiscoverable_scan().
+PASSIVE_SCAN_OR_PATTERNS = [
+    (0, AdvertisementDataType.FLAGS, bytes([0x02])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x04])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x05])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x06])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x0e])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x1a])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x1e])),
+]
+
+NONDISCOVERABLE_SCAN_INTERVAL = 30
+NONDISCOVERABLE_SCAN_DURATION = 15
 
 class DbusBleSensors(object):
     """
@@ -106,100 +131,330 @@ class DbusBleSensors(object):
             self._adapters.remove(name)
             logging.info(f"{name}: adapter removed")
 
-    async def _scan(self, adapter: str):
-        def _scan_callback(device, advertisement_data):
-            dev_mac = "".join(device.address.split(':')).lower()
-            if dev_mac in self._ignored_mac:
-                # Ignoring devices already evaluated
-                return
+    def _process_advertisement(self, device, advertisement_data):
+        """Process a single BLE advertisement (called from scan_loop on the main thread)."""
+        dev_mac = "".join(device.address.split(':')).lower()
+        if dev_mac in self._ignored_mac:
+            return
 
-            plog = f"{dev_mac} - {device.name}:"
-            logging.debug(f"{plog} received advertisement {advertisement_data!r}")
-            if advertisement_data.manufacturer_data is None or len(advertisement_data.manufacturer_data) < 1:
-                logging.info(f"{plog} ignoring, device without manufacturer data")
-                self._ignored_mac[dev_mac] = True
-                return
+        plog = f"{dev_mac} - {device.name}:"
+        logging.debug(f"{plog} received advertisement {advertisement_data!r}")
+        if advertisement_data.manufacturer_data is None or len(advertisement_data.manufacturer_data) < 1:
+            logging.info(f"{plog} ignoring, device without manufacturer data")
+            self._ignored_mac[dev_mac] = True
+            return
 
-            # Loop through manufacturer data fields, even though most devices only use one
-            for man_id, man_data in advertisement_data.manufacturer_data.items():
-                if dev_mac not in self._known_mac:
-                    # Snif new device advertising data
-                    self.snif_data(man_id, man_data)
+        for man_id, man_data in advertisement_data.manufacturer_data.items():
+            if dev_mac not in self._known_mac:
+                self.snif_data(man_id, man_data)
 
-                    # Get device class from manufacturer id
-                    device_class = BleDevice.DEVICE_CLASSES.get(man_id, None)
-                    if device_class is None:
-                        logging.info(f"{plog} ignoring data {man_data!r}, no device configuration class for manufacturer {man_id!r}")
-                        self._ignored_mac[dev_mac] = True
-                        continue
+                device_class = BleDevice.DEVICE_CLASSES.get(man_id, None)
+                if device_class is None:
+                    logging.info(f"{plog} ignoring data {man_data!r}, no device configuration class for manufacturer {man_id!r}")
+                    self._ignored_mac[dev_mac] = True
+                    continue
 
-                    # Run device specific parsing
-                    logging.info(f"{plog} initializing device with class {device_class}")
-                    try:
-                        dev_instance = device_class(dev_mac)
-                        if not dev_instance.check_manufacturer_data(man_data):
-                            raise ValueError(f"{plog} ignoring data {man_data!r}, manufacturer data check failed")
-                        dev_instance.configure(man_data)
-                        dev_instance.init()
-                        self._known_mac[dev_mac] = dev_instance
-                    except Exception as e:
-                        logging.exception(f"{plog} ignoring data {man_data!r}, an error occurred during device initialization:")
-                        self._ignored_mac[dev_mac] = True
-                        continue
-                else:
-                    dev_instance = self._known_mac[dev_mac]
-
-                # Parsing data
-                logging.info(f"{plog} received manufacturer data: {man_data!r}")
-                if dev_instance.check_manufacturer_data(man_data):
-                    dev_instance.handle_manufacturer_data(man_data)
-                else:
-                    logging.info(f"{plog} ignoring manufacturer data due to data check")
-
-        logging.debug(f"{adapter}: Scanning ...")
-        try:
-            async with bleak.BleakScanner(adapter=adapter, detection_callback=_scan_callback) as scanner:
-                await asyncio.sleep(SCAN_TIMEOUT)
-            logging.debug(f"{adapter}: Scan finished")
-        except Exception:
-            logging.exception(f"{adapter}: Scan error")
-
-        try:
-            async with bleak.BleakScanner(
-                adapter=adapter,
-                detection_callback=_scan_callback,
-                bluez=dict(filters={"DuplicateData": True}),
-            ) as scanner:
-                await asyncio.sleep(NONDISCOVERABLE_SCAN_TIMEOUT)
-            logging.debug(f"{adapter}: Nondiscoverable scan finished")
-        except bleak.exc.BleakDBusError as e:
-            if "InProgress" in str(e):
-                logging.debug(f"{adapter}: nondiscoverable scan skipped (InProgress)")
+                logging.info(f"{plog} initializing device with class {device_class}")
+                try:
+                    dev_instance = device_class(dev_mac)
+                    if not dev_instance.check_manufacturer_data(man_data):
+                        raise ValueError(f"{plog} ignoring data {man_data!r}, manufacturer data check failed")
+                    dev_instance.configure(man_data)
+                    dev_instance.init()
+                    self._known_mac[dev_mac] = dev_instance
+                except Exception as e:
+                    logging.exception(f"{plog} ignoring data {man_data!r}, an error occurred during device initialization:")
+                    self._ignored_mac[dev_mac] = True
+                    continue
             else:
-                logging.warning(f"{adapter}: nondiscoverable scan error: {e}")
-        except Exception:
-            logging.warning(f"{adapter}: nondiscoverable scan error", exc_info=True)
+                dev_instance = self._known_mac[dev_mac]
+
+            logging.info(f"{plog} received manufacturer data: {man_data!r}")
+            if dev_instance.check_manufacturer_data(man_data):
+                dev_instance.handle_manufacturer_data(man_data)
+            else:
+                logging.info(f"{plog} ignoring manufacturer data due to data check")
+
+    def _start_scanners(self):
+        """Start BLE scanners in background threads.
+
+        Passive scanners and nondiscoverable (DuplicateData) scanners run in
+        separate threads, each with its own asyncio event loop.  This is
+        necessary because:
+
+        1. The main thread uses gbulb (GLib-backed asyncio) which is
+           incompatible with dbus-fast's method-call dispatch needed for
+           passive scanning via AdvertisementMonitor1.
+
+        2. If passive scanning's AdvertisementMonitor1 callbacks fail (e.g.
+           method signature mismatch with BlueZ), the dbus-fast connection
+           can block the event loop, preventing nondiscoverable scans from
+           starting.  Separate threads with separate event loops isolate
+           the two scanning modes from each other."""
+        self._scan_buffer = []
+        self._scan_buffer_lock = threading.Lock()
+        self._scanner_stop = threading.Event()
+
+        def _make_thread(coro_factory, name):
+            def _thread_main():
+                asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                try:
+                    loop.run_until_complete(coro_factory())
+                except Exception:
+                    logging.exception(f"{name} thread error")
+            t = threading.Thread(target=_thread_main, daemon=True, name=name)
+            t.start()
+            return t
+
+        self._scanner_thread = _make_thread(
+            self._run_scanners, "passive-scanner")
+        self._nd_scanner_thread = _make_thread(
+            self._run_nondiscoverable_scans, "nondiscoverable-scanner")
+
+    @staticmethod
+    async def _power_cycle_adapter(adapter):
+        """Power-cycle a BlueZ adapter to clear corrupted HCI scan state.
+
+        When the C-based dbus-ble-sensors service uses raw HCI sockets with
+        legacy scan commands (0x200B/0x200C) on a BT 5.x adapter, BlueZ
+        cannot disable the orphaned scan because it sends extended commands
+        (0x2041/0x2042) which the controller rejects (Command Disallowed /
+        EBUSY).  Power-cycling via D-Bus triggers a proper HCI Reset that
+        clears all controller state."""
+        from dbus_fast.aio import MessageBus
+        from dbus_fast import BusType, Variant
+
+        adapter_path = f'/org/bluez/{adapter}'
+        logging.info(f"{adapter}: power-cycling to clear HCI state")
+        bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+        try:
+            introspection = await bus.introspect('org.bluez', adapter_path)
+            proxy = bus.get_proxy_object('org.bluez', adapter_path, introspection)
+            props = proxy.get_interface('org.freedesktop.DBus.Properties')
+            await props.call_set('org.bluez.Adapter1', 'Powered', Variant('b', False))
+            await asyncio.sleep(1)
+            await props.call_set('org.bluez.Adapter1', 'Powered', Variant('b', True))
+            await asyncio.sleep(2)
+            logging.info(f"{adapter}: power-cycle complete")
+        except Exception as e:
+            logging.warning(f"{adapter}: power-cycle failed: {e}")
+        finally:
+            bus.disconnect()
+
+    async def _run_scanners(self):
+        """Run persistent BleakScanners with per-adapter state tracking.
+
+        Each adapter starts in passive mode.  On failure, retries with
+        exponential backoff up to MAX_PASSIVE_RETRIES times.  After that,
+        power-cycles the adapter via D-Bus to clear any corrupted HCI scan
+        state (e.g. from the C-based dbus-ble-sensors service using raw HCI
+        sockets with legacy commands on a BT 5.x adapter).  If passive
+        scanning still fails after the power-cycle, falls back to one
+        active scan cycle before returning to passive.
+        Mode transitions are logged at INFO level per adapter."""
+        INITIAL_BACKOFF = SCANNER_INITIAL_BACKOFF
+        MAX_BACKOFF = SCANNER_MAX_BACKOFF
+        MAX_PASSIVE_RETRIES = SCANNER_MAX_PASSIVE_RETRIES
+        ACTIVE_CYCLE_DURATION = SCANNER_ACTIVE_CYCLE_DURATION
+
+        def _detection_callback(device, adv_data):
+            with self._scan_buffer_lock:
+                self._scan_buffer.append((device, adv_data))
+
+        adapter_state = {}
+
+        def _state(adapter):
+            if adapter not in adapter_state:
+                adapter_state[adapter] = {
+                    'mode': 'passive',
+                    'scanner': None,
+                    'retries': 0,
+                    'backoff': INITIAL_BACKOFF,
+                    'retry_at': 0.0,
+                    'logged_mode': None,
+                    'power_cycled': False,
+                }
+            return adapter_state[adapter]
+
+        def _log_mode(adapter, st, reason=''):
+            if st['logged_mode'] != st['mode']:
+                suffix = f' ({reason})' if reason else ''
+                logging.info(f"{adapter}: scanning mode: {st['mode']}{suffix}")
+                st['logged_mode'] = st['mode']
+
+        while not self._scanner_stop.is_set():
+            now = asyncio.get_event_loop().time()
+
+            for adapter in self._adapters:
+                st = _state(adapter)
+
+                if st['scanner'] is not None:
+                    continue
+                if now < st['retry_at']:
+                    continue
+
+                if st['mode'] == 'passive':
+                    try:
+                        scanner = bleak.BleakScanner(
+                            detection_callback=_detection_callback,
+                            scanning_mode='passive',
+                            bluez=dict(or_patterns=PASSIVE_SCAN_OR_PATTERNS, adapter=adapter),
+                        )
+                        await scanner.start()
+                        st['scanner'] = scanner
+                        st['retries'] = 0
+                        st['backoff'] = INITIAL_BACKOFF
+                        _log_mode(adapter, st)
+                    except Exception as e:
+                        st['retries'] += 1
+                        delay = st['backoff']
+                        st['backoff'] = min(delay * 2, MAX_BACKOFF)
+                        st['retry_at'] = now + delay
+
+                        if st['retries'] >= MAX_PASSIVE_RETRIES:
+                            if not st['power_cycled']:
+                                logging.warning(
+                                    f"{adapter}: passive scan failed {st['retries']} times, "
+                                    f"power-cycling adapter to clear HCI state"
+                                )
+                                await self._power_cycle_adapter(adapter)
+                                st['power_cycled'] = True
+                                st['retries'] = 0
+                                st['backoff'] = INITIAL_BACKOFF
+                                st['retry_at'] = 0.0
+                                st['logged_mode'] = None
+                            else:
+                                logging.warning(
+                                    f"{adapter}: passive scan still failing after power-cycle, "
+                                    f"falling back to active for one cycle"
+                                )
+                                st['mode'] = 'active'
+                                st['retry_at'] = 0.0
+                        else:
+                            logging.warning(
+                                f"{adapter}: passive scan start failed ({e}), "
+                                f"retry {st['retries']}/{MAX_PASSIVE_RETRIES} in {delay:.0f}s"
+                            )
+
+                elif st['mode'] == 'active':
+                    try:
+                        scanner = bleak.BleakScanner(
+                            detection_callback=_detection_callback,
+                            bluez=dict(adapter=adapter),
+                        )
+                        await scanner.start()
+                        _log_mode(adapter, st, reason='fallback')
+
+                        for _ in range(ACTIVE_CYCLE_DURATION):
+                            if self._scanner_stop.is_set():
+                                break
+                            await asyncio.sleep(1)
+
+                        await scanner.stop()
+                    except bleak.exc.BleakDBusError as e:
+                        if "InProgress" in str(e):
+                            logging.debug(f"{adapter}: active scan InProgress, will retry")
+                        else:
+                            logging.warning(f"{adapter}: active scan error: {e}")
+                    except Exception as e:
+                        logging.warning(f"{adapter}: active scan error: {e}")
+
+                    st['mode'] = 'passive'
+                    st['retries'] = 0
+                    st['backoff'] = INITIAL_BACKOFF
+                    st['retry_at'] = 0.0
+                    st['power_cycled'] = False
+                    logging.info(f"{adapter}: active cycle complete, retrying passive")
+
+            await asyncio.sleep(1)
+
+        for adapter, st in adapter_state.items():
+            if st['scanner'] is not None:
+                try:
+                    await st['scanner'].stop()
+                    logging.info(f"{adapter}: scanner stopped")
+                except Exception:
+                    pass
+
+    async def _run_nondiscoverable_scans(self):
+        """Periodic active scans with DuplicateData=True to detect devices
+        that omit the Flags AD type (e.g. Mopeka sensors advertise only
+        manufacturer data under Nordic's company ID 0x0059 with no Flags).
+
+        These scans run alongside the persistent passive scanners.  If the
+        adapter is busy (InProgress), the scan is silently skipped."""
+        while not self._scanner_stop.is_set():
+            await asyncio.sleep(NONDISCOVERABLE_SCAN_INTERVAL)
+            for adapter in list(self._adapters):
+                try:
+                    nd_results = []
+
+                    def _nd_callback(device, adv_data):
+                        nd_results.append((device, adv_data))
+
+                    scanner = bleak.BleakScanner(
+                        detection_callback=_nd_callback,
+                        bluez=dict(
+                            adapter=adapter,
+                            filters={"DuplicateData": True},
+                        ),
+                    )
+                    await scanner.start()
+                    for _ in range(NONDISCOVERABLE_SCAN_DURATION):
+                        if self._scanner_stop.is_set():
+                            break
+                        await asyncio.sleep(1)
+                    await scanner.stop()
+
+                    with self._scan_buffer_lock:
+                        self._scan_buffer.extend(nd_results)
+                    logging.info(
+                        f"{adapter}: nondiscoverable scan finished "
+                        f"({len(nd_results)} advertisements)"
+                    )
+                except bleak.exc.BleakDBusError as e:
+                    if "InProgress" in str(e):
+                        logging.debug(
+                            f"{adapter}: nondiscoverable scan skipped (InProgress)"
+                        )
+                    else:
+                        logging.warning(
+                            f"{adapter}: nondiscoverable scan error: {e}"
+                        )
+                except Exception as e:
+                    logging.warning(
+                        f"{adapter}: nondiscoverable scan error: {e}"
+                    )
 
     async def scan_loop(self):
+        DRAIN_INTERVAL = 5
+
         while True:
-            # Start scans on all adapters
             if len(self._adapters) < 1:
                 logging.warning("Waiting for a bluetooth adapter...")
                 await asyncio.sleep(5)
                 continue
-            scan_tasks = [asyncio.create_task(self._scan(adapter)) for adapter in self._adapters]
-            await asyncio.gather(*scan_tasks)
 
-            # Clean known/ignored device lists
+            if not hasattr(self, '_scanner_thread'):
+                self._start_scanners()
+                await asyncio.sleep(DRAIN_INTERVAL)
+
+            with self._scan_buffer_lock:
+                results = self._scan_buffer[:]
+                self._scan_buffer.clear()
+
+            for device, ad_data in results:
+                try:
+                    self._process_advertisement(device, ad_data)
+                except Exception:
+                    logging.exception(f"Error processing advertisement from {device.address}")
+
             self._known_mac.prune()
             self._ignored_mac.prune()
 
-            # Wait before next scan if needed
-            if self._dbus_ble_service.get_continuous_scan():
-                logging.debug(f"{self._adapters}: continuous scan on, restarting scan immediately")
-            else:
-                logging.debug(f"{self._adapters}: continuous scan off, pausing for {SCAN_SLEEP!r} seconds")
-                await asyncio.sleep(SCAN_SLEEP)
+            await asyncio.sleep(DRAIN_INTERVAL)
 
     def snif_data(self, man_id: int, man_data: bytes):
         """

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_service.py
@@ -137,15 +137,22 @@ class DbusBleService(object):
             self._set_value(f"/Devices/{dev_id}_{role_name}/Name", f"{custom_name_changes['Value']} {role_name}")
         self._dbus_settings.get_item(custom_name_setting_path).eventCallback = set_name_callback
 
-        # Add enable entry
+        # Add enable entry and fire the callback with the persisted value so
+        # that roles already enabled at startup get their D-Bus service
+        # connected immediately (on_enabled_changed is only called on
+        # *changes* by _set_proxy_setting, not for the initial value).
+        enabled_setting_path = f"/Settings/Devices/{dbus_role_service.get_dbus_id()}/Enabled"
         self._set_proxy_setting(
-            f"/Settings/Devices/{dbus_role_service.get_dbus_id()}/Enabled",
+            enabled_setting_path,
             f"/Devices/{dev_id}_{role_name}/Enabled",
             0,
             0,
             1,
             dbus_role_service.on_enabled_changed
         )
+        initial = self._dbus_settings.get_value(enabled_setting_path)
+        if initial:
+            dbus_role_service.on_enabled_changed(initial)
 
     def unregister_role_service(self, dbus_role_service):
         role_name = dbus_role_service.ble_role.NAME

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_mopeka.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_mopeka.py
@@ -39,18 +39,8 @@ class BleDeviceSafieryTests(BleDeviceBaseTests):
                     'HardwareID': 3,
                     'TankLevelExtension': 0,
                     'BatteryVoltage': 3.125,
+                    'Temperature': 20.0,
                     'RawValue': 5000,
                 },
-                "temperature": {
-                    'HardwareID': 3,
-                    'BatteryVoltage': 3.125,
-                    'Temperature': 20.0,
-                },
-                "movement": {
-                    'HardwareID': 3,
-                    'BatteryVoltage': 3.125,
-                    'AccelX': -0.01171875,
-                    'AccelY': 0.0078125,
-                }
             }
         )

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_mopeka_scaling.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_mopeka_scaling.py
@@ -1,0 +1,401 @@
+"""
+Tests for Mopeka sensor data parsing and scaling calculations.
+
+Uses raw BLE advertisement captures from real Mopeka Pro LPG sensors on
+a 2025 Airstream Flying Cloud 30' FB Bunk (two 30lb steel propane tanks).
+
+Verifies:
+  - Register parsing matches the C implementation (mopeka.c)
+  - Temperature-dependent polynomial scaling of RawValue
+  - Butane ratio scaling matches C: both coefficients multiplied by r
+  - End-to-end pipeline: raw bytes → scaled cm → level percentage
+"""
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock
+
+# Mock D-Bus modules before any imports that need them
+for _mod in ['dbus', 'dbus.mainloop.glib', 'vedbus', 'settingsdevice', 'dbusmonitor']:
+    sys.modules[_mod] = MagicMock()
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'ext'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'ext', 'velib_python'))
+
+from ble_device_mopeka import BleDeviceMopeka
+from ble_role_tank import BleRoleTank
+from ble_role import BleRole
+
+
+# Raw advertisement captures from btmon (manufacturer_id=0x0059 payload only)
+# Sensor: Mopeka Pro LPG, HW ID 3
+RAW_STEEL_R = [
+    # CB:15:7D:29:61:44 — NIC bytes at [5:8] = 29 61 44
+    bytes.fromhex('03593adb80296144e6f9'),
+    bytes.fromhex('03593adb80296144edfd'),
+    bytes.fromhex('03593adb80296144e900'),
+    bytes.fromhex('035a3adb80296144ebf9'),
+    bytes.fromhex('03593adb80296144ebfb'),
+    bytes.fromhex('03593adb80296144f0f6'),
+]
+
+RAW_STEEL_L = [
+    # F4:5F:E6:A3:DA:F4 — NIC bytes at [5:8] = a3 da f4
+    bytes.fromhex('03593bdc80a3daf40419'),
+    bytes.fromhex('03593bdc80a3daf40416'),
+    bytes.fromhex('035a3bdc80a3daf40019'),
+    bytes.fromhex('035a3bdc80a3daf4fd12'),
+    bytes.fromhex('03593bdc80a3daf4001b'),
+    bytes.fromhex('03593bdc80a3daf40619'),
+    bytes.fromhex('03593bdd80a3daf40419'),
+]
+
+
+class TestMopekaRegisterParsing(unittest.TestCase):
+    """Test that register parsing extracts correct values from raw bytes."""
+
+    @classmethod
+    def setUpClass(cls):
+        BleRole.load_classes(os.path.dirname(os.path.abspath(__file__)))
+
+    def _make_device(self, mac, raw):
+        dev = BleDeviceMopeka(mac)
+        dev.configure(raw)
+        dev._load_configuration()
+        return dev
+
+    def test_steel_r_parsing(self):
+        raw = RAW_STEEL_R[0]  # 03593adb80296144e6f9
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+
+        self.assertEqual(parsed['tank']['HardwareID'], 3)
+        self.assertEqual(parsed['tank']['TankLevelExtension'], 0)
+        self.assertEqual(parsed['tank']['BatteryVoltage'], 89 / 32)  # 2.78125
+        self.assertEqual(parsed['tank']['Temperature'], 18.0)  # 58 - 40
+        self.assertEqual(parsed['tank']['RawValue'], 219)
+
+        self.assertNotIn('temperature', parsed,
+                         "Mopeka should not have a separate temperature role")
+
+    def test_single_tank_role_only(self):
+        """Mopeka creates one tank service, not separate temperature/movement services.
+        Matches C implementation which exposes /Temperature on the tank service."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        self.assertEqual(list(parsed.keys()), ['tank'])
+
+    def test_steel_l_parsing(self):
+        raw = RAW_STEEL_L[0]  # 03593bdc80a3daf40419
+        dev = self._make_device('f45fe6a3daf4', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+
+        self.assertEqual(parsed['tank']['HardwareID'], 3)
+        self.assertEqual(parsed['tank']['Temperature'], 19.0)  # 59 - 40
+        self.assertEqual(parsed['tank']['RawValue'], 220)
+
+    def test_steel_l_raw_221(self):
+        raw = RAW_STEEL_L[6]  # 03593bdd80... — RawValue should be 221
+        dev = self._make_device('f45fe6a3daf4', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        self.assertEqual(parsed['tank']['RawValue'], 221)
+
+    def test_temperature_in_tank_role(self):
+        """Temperature must be in the tank role data for scaling calculation.
+        The C implementation (mopeka_xlate_level) reads Temperature from the
+        flat VeItem tree; the Python port must include it in the tank role."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        self.assertIn('Temperature', parsed['tank'],
+                      "Temperature must be available in tank role for scaling")
+
+    def test_nic_check_rejects_wrong_mac(self):
+        raw = RAW_STEEL_R[0]  # NIC = 29 61 44
+        dev = self._make_device('aabbccddeeff', raw)
+        dev.configure(raw)
+        dev._load_configuration()
+        self.assertFalse(dev.check_manufacturer_data(raw))
+
+    def test_nic_check_accepts_correct_mac(self):
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        self.assertTrue(dev.check_manufacturer_data(raw))
+
+    def test_all_steel_r_samples_pass_nic(self):
+        for i, raw in enumerate(RAW_STEEL_R):
+            dev = self._make_device('cb157d296144', raw)
+            self.assertTrue(dev.check_manufacturer_data(raw),
+                            f"Steel R sample {i} failed NIC check")
+
+    def test_all_steel_l_samples_pass_nic(self):
+        for i, raw in enumerate(RAW_STEEL_L):
+            dev = self._make_device('f45fe6a3daf4', raw)
+            self.assertTrue(dev.check_manufacturer_data(raw),
+                            f"Steel L sample {i} failed NIC check")
+
+    def test_cross_contamination_rejected(self):
+        """Steel R data must NOT pass Steel L's NIC check, and vice versa."""
+        raw_r = RAW_STEEL_R[0]
+        raw_l = RAW_STEEL_L[0]
+
+        dev_r = self._make_device('cb157d296144', raw_r)
+        dev_l = self._make_device('f45fe6a3daf4', raw_l)
+
+        self.assertFalse(dev_r.check_manufacturer_data(raw_l),
+                         "Steel R device must reject Steel L data")
+        self.assertFalse(dev_l.check_manufacturer_data(raw_r),
+                         "Steel L device must reject Steel R data")
+
+    def test_battery_voltage_variation(self):
+        """Battery voltage should vary between samples (byte 1 = 0x59 or 0x5a)."""
+        dev = self._make_device('f45fe6a3daf4', RAW_STEEL_L[0])
+        voltages = set()
+        for raw in RAW_STEEL_L:
+            parsed = dev._parse_manufacturer_data(raw)
+            voltages.add(parsed['tank']['BatteryVoltage'])
+        self.assertTrue(len(voltages) >= 2,
+                        f"Expected battery voltage variation, got {voltages}")
+
+
+class TestMopekaScaling(unittest.TestCase):
+    """Test the temperature-dependent polynomial scaling of RawValue."""
+
+    @classmethod
+    def setUpClass(cls):
+        BleRole.load_classes(os.path.dirname(os.path.abspath(__file__)))
+
+    def _make_device(self, mac, raw):
+        dev = BleDeviceMopeka(mac)
+        dev.configure(raw)
+        dev._load_configuration()
+        return dev
+
+    def _mock_role_service(self, butane_ratio=0, fluid_type=8):
+        svc = {
+            'ButaneRatio': butane_ratio,
+            'FluidType': fluid_type,
+            'BatteryVoltage': 2.78125,
+        }
+        mock = MagicMock()
+        mock.__getitem__ = lambda self_m, key: svc[key]
+        mock.ble_role = MagicMock()
+        mock.ble_role.NAME = 'tank'
+        return mock
+
+    def test_butane_scale_zero_ratio(self):
+        """With ButaneRatio=0, butane contribution must be exactly 0.
+        Matches C: mopeka_coefs_butane[0] * r + mopeka_coefs_butane[1] * r * temp"""
+        dev = BleDeviceMopeka('000000000000')
+        result = dev._get_scale_butane(0, 58)
+        self.assertEqual(result, 0.0)
+
+    def test_butane_scale_nonzero_ratio(self):
+        """With ButaneRatio=50, verify against C formula."""
+        dev = BleDeviceMopeka('000000000000')
+        r = 50 / 100.0
+        temp = 58
+        expected = 0.03615 * r + 0.000815 * r * temp
+        result = dev._get_scale_butane(50, temp)
+        self.assertAlmostEqual(result, expected, places=10)
+
+    def test_butane_scale_full_ratio(self):
+        dev = BleDeviceMopeka('000000000000')
+        r = 1.0
+        temp = 58
+        expected = 0.03615 * r + 0.000815 * r * temp
+        result = dev._get_scale_butane(100, temp)
+        self.assertAlmostEqual(result, expected, places=10)
+
+    def test_scaling_steel_r(self):
+        """Verify scaling matches C mopeka_xlate_level for Steel R raw capture."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        role_svc = self._mock_role_service(butane_ratio=0)
+        dev.update_data(role_svc, tank_data)
+
+        # C calculation: temp=58, raw=219, coefs_lpg, butane_scale=0
+        # scale = 0.573045 + (-0.002822 * 58) + (-0.00000535 * 58 * 58) = 0.391372
+        # RawValue = (219 * 0.391372) / 10 = 8.5710
+        self.assertAlmostEqual(tank_data['RawValue'], 8.571, places=2)
+
+    def test_scaling_steel_l(self):
+        """Verify scaling for Steel L (different temperature and raw value)."""
+        raw = RAW_STEEL_L[0]  # temp=19°C, raw=220
+        dev = self._make_device('f45fe6a3daf4', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        role_svc = self._mock_role_service(butane_ratio=0)
+        dev.update_data(role_svc, tank_data)
+
+        # temp=59, raw=220, coefs_lpg, butane_scale=0
+        # scale = 0.573045 + (-0.002822 * 59) + (-0.00000535 * 59 * 59) = 0.387924
+        # RawValue = (220 * 0.387924) / 10 = 8.5343
+        self.assertAlmostEqual(tank_data['RawValue'], 8.534, places=2)
+
+    def test_scaling_skipped_for_non_tank_role(self):
+        """update_data must be a no-op when called with a non-tank role."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+
+        fake_data = {'Temperature': 18.0, 'BatteryVoltage': 2.78125}
+        original = fake_data.copy()
+
+        temp_svc = MagicMock()
+        temp_svc.ble_role = MagicMock()
+        temp_svc.ble_role.NAME = 'temperature'
+        dev.update_data(temp_svc, fake_data)
+        self.assertEqual(fake_data, original, "Non-tank role data must not be modified")
+
+    def test_sensors_produce_different_values(self):
+        """Steel R and Steel L must produce measurably different scaled values."""
+        dev_r = self._make_device('cb157d296144', RAW_STEEL_R[0])
+        dev_l = self._make_device('f45fe6a3daf4', RAW_STEEL_L[0])
+
+        parsed_r = dev_r._parse_manufacturer_data(RAW_STEEL_R[0])
+        parsed_l = dev_l._parse_manufacturer_data(RAW_STEEL_L[0])
+        tank_r = dict(parsed_r['tank'])
+        tank_l = dict(parsed_l['tank'])
+
+        role_svc = self._mock_role_service(butane_ratio=0)
+        dev_r.update_data(role_svc, tank_r)
+        dev_l.update_data(role_svc, tank_l)
+
+        self.assertNotEqual(tank_r['RawValue'], tank_l['RawValue'],
+                            "Steel R and L must have different scaled values")
+        self.assertNotEqual(parsed_r['tank']['Temperature'],
+                            parsed_l['tank']['Temperature'],
+                            "Steel R and L must have different temperatures")
+
+
+class TestMopekaEndToEnd(unittest.TestCase):
+    """Test the full pipeline: raw bytes → scaling → level calculation."""
+
+    @classmethod
+    def setUpClass(cls):
+        BleRole.load_classes(os.path.dirname(os.path.abspath(__file__)))
+
+    def _make_device(self, mac, raw):
+        dev = BleDeviceMopeka(mac)
+        dev.configure(raw)
+        dev._load_configuration()
+        return dev
+
+    def _mock_role_service(self, raw_empty=0.0, raw_full=40.4, capacity=0.02649788):
+        return {
+            'ButaneRatio': 0,
+            'FluidType': 8,
+            'BatteryVoltage': 2.78125,
+            'RawValue': 0.0,
+            'RawValueEmpty': raw_empty,
+            'RawValueFull': raw_full,
+            'Capacity': capacity,
+            'Shape': '',
+            'Level': 0,
+            'Remaining': 0.0,
+        }
+
+    def test_steel_r_full_pipeline(self):
+        """Raw bytes → Mopeka scaling → tank level computation → ~21%."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        role_svc_mock = MagicMock()
+        role_svc_mock.__getitem__ = lambda s, k: {'ButaneRatio': 0, 'FluidType': 8}[k]
+        role_svc_mock.ble_role = MagicMock()
+        role_svc_mock.ble_role.NAME = 'tank'
+
+        # Step 1: Device scaling (must run first, per C xlate pattern)
+        dev.update_data(role_svc_mock, tank_data)
+        scaled_raw = tank_data['RawValue']
+        self.assertAlmostEqual(scaled_raw, 8.571, places=2)
+
+        # Step 2: Role level computation
+        tank_role = BleRoleTank(config={'flags': []})
+        tank_role._parse_shape_str('')
+        dbus_svc = self._mock_role_service()
+        level, remaining, status = tank_role._compute_level(
+            rawValue=scaled_raw,
+            empty=dbus_svc['RawValueEmpty'],
+            full=dbus_svc['RawValueFull'],
+            capacity=dbus_svc['Capacity'],
+        )
+        self.assertEqual(level, 21)
+        self.assertEqual(status, 0)
+
+    def test_steel_l_full_pipeline(self):
+        """Steel L should also produce ~21% but with different intermediate values."""
+        raw = RAW_STEEL_L[0]
+        dev = self._make_device('f45fe6a3daf4', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        role_svc_mock = MagicMock()
+        role_svc_mock.__getitem__ = lambda s, k: {'ButaneRatio': 0, 'FluidType': 8}[k]
+        role_svc_mock.ble_role = MagicMock()
+        role_svc_mock.ble_role.NAME = 'tank'
+
+        dev.update_data(role_svc_mock, tank_data)
+        scaled_raw = tank_data['RawValue']
+        self.assertAlmostEqual(scaled_raw, 8.534, places=2)
+
+        tank_role = BleRoleTank(config={'flags': []})
+        tank_role._parse_shape_str('')
+        dbus_svc = self._mock_role_service()
+        level, remaining, status = tank_role._compute_level(
+            rawValue=scaled_raw,
+            empty=dbus_svc['RawValueEmpty'],
+            full=dbus_svc['RawValueFull'],
+            capacity=dbus_svc['Capacity'],
+        )
+        self.assertEqual(level, 21)
+        self.assertEqual(status, 0)
+
+    def test_wrong_execution_order_gives_wrong_level(self):
+        """If role update_data runs before device update_data, Level is wrong.
+        This regression test ensures the execution order fix stays in place."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        # Wrong order: role first (computes Level from UNSCALED RawValue=219)
+        tank_role = BleRoleTank(config={'flags': []})
+        tank_role._parse_shape_str('')
+        dbus_svc = self._mock_role_service()
+        level_wrong, _, _ = tank_role._compute_level(
+            rawValue=float(tank_data['RawValue']),  # 219 (unscaled!)
+            empty=dbus_svc['RawValueEmpty'],
+            full=dbus_svc['RawValueFull'],
+            capacity=dbus_svc['Capacity'],
+        )
+        self.assertEqual(level_wrong, 100,
+                         "Unscaled RawValue should overflow to 100%")
+
+        # Correct order: device first (scales RawValue), then role
+        role_svc_mock = MagicMock()
+        role_svc_mock.__getitem__ = lambda s, k: {'ButaneRatio': 0, 'FluidType': 8}[k]
+        role_svc_mock.ble_role = MagicMock()
+        role_svc_mock.ble_role.NAME = 'tank'
+        dev.update_data(role_svc_mock, tank_data)
+
+        level_correct, _, _ = tank_role._compute_level(
+            rawValue=float(tank_data['RawValue']),  # ~8.57 (scaled)
+            empty=dbus_svc['RawValueEmpty'],
+            full=dbus_svc['RawValueFull'],
+            capacity=dbus_svc['Capacity'],
+        )
+        self.assertEqual(level_correct, 21,
+                         "Scaled RawValue should give ~21%")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Certain BLE sensors (e.g. Mopeka) advertise without the standard Flags AD type (0x01). BlueZ treats these as "non-discoverable" and silently drops them during active scanning when `DuplicateData` is `False` (the default). This means Mopeka and similar devices are never detected, even though they broadcast valid manufacturer data.

This PR fixes three detection issues and four Mopeka data-processing bugs:

### Detection Fixes

- **Non-discoverable device detection**: After each normal scan cycle, a supplementary scan with `DuplicateData=True` runs to catch all advertisements regardless of discoverability flags. Devices like Mopeka (which use Nordic Semiconductor company ID `0x0059` with no Flags) now reliably appear.

- **Role service startup bug**: `_set_proxy_setting` only fires `on_enabled_changed` on value *changes*, not for the initial persisted value. If a role was previously enabled (`Enabled=1`), restarting the service would not reconnect its D-Bus service. `register_role_service` now explicitly invokes the callback with the initial setting value.

- **Battery alarm crash**: `_get_low_battery_state` in both `ble_device_mopeka.py` and `ble_device_safiery.py` called `role_service.get('BatteryVoltage', None)`, but `DbusRoleService` only supports bracket access (`role_service['BatteryVoltage']`). This caused an `AttributeError` when alarm updates ran, crashing the scan callback.

### Mopeka Fixes (see also PR #6)

- **Temperature data unavailable for scaling**: Temperature was filtered to the `temperature` role only, making it unavailable when `update_data()` runs the RawValue scaling. Fixed by routing Temperature to the `tank` role.

- **Wrong execution order → Level always 100%**: `BleRoleTank.update_data()` (Level computation) ran before `BleDeviceMopeka.update_data()` (RawValue scaling), so Level was computed from the unscaled ultrasonic value, always overflowing to 100%.

- **Butane scaling bug**: `_get_scale_butane()` added the constant coefficient even with `ButaneRatio=0` (pure propane), inflating values ~9%. Aligned with C formula.

- **Role consolidation**: Each Mopeka sensor registered three separate D-Bus services (tank, temperature, movement). Consolidated to a single `com.victronenergy.tank` service with `/Temperature` and `/BatteryVoltage` as additional paths, matching the C implementation and Victron wiki.

Also adds `self._ignored_mac[dev_mac] = True` on device initialization failure to prevent log spam from devices that consistently fail.

## Affected Devices

Any BLE sensor that advertises without a Flags AD type, including:
- Mopeka Pro Check (all variants)
- Potentially other devices using manufacturer-data-only advertisements

## Test Plan

- [x] 21 new Mopeka scaling tests using raw BLE captures (all pass)
- [x] Verified on Cerbo GX with two Mopeka Pro LPG sensors reading correct ~21% level
- [x] Mopeka sensors show as single tank device (not three separate devices)
- [x] Temperature and BatteryVoltage available on tank D-Bus service
- [ ] Verify Ruuvi, Safiery, and other Flags-based sensors continue to work normally
- [ ] Verify no excessive log spam from encrypted/unsupported devices during DuplicateData scans
- [ ] Verify pre-enabled roles reconnect their D-Bus services after service restart