### PR TITLE
Cache D-Bus connections to prevent connection proliferation

### DIFF
--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
@@ -334,9 +334,10 @@ class BleDevice(object):
             # Filtering data
             role_data = sensor_data[role_service.ble_role.NAME]
             if role_data:
-                # Update sensor data from update callbacks
-                role_service.ble_role.update_data(role_service, role_data)
+                # Device-level transform first (e.g. Mopeka xlate scaling),
+                # then role-level computation (e.g. tank Level from RawValue).
                 self.update_data(role_service, role_data)
+                role_service.ble_role.update_data(role_service, role_data)
 
                 # Update Dbus with new data
                 self._update_dbus_data(role_service, role_data)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device.py
@@ -21,6 +21,7 @@ class BleDevice(object):
     """
 
     MANUFACTURER_ID = None  # To be overloaded in children classes: int, ble manufacturer id
+    CUSTOM_PARSING = False  # Set True in subclasses that override handle_manufacturer_data() and don't use regs
 
     # Dict of devices classes, key is manufacturer id
     DEVICE_CLASSES = {}
@@ -142,9 +143,10 @@ class BleDevice(object):
             if not isinstance(self.info[dict_key], dict):
                 raise ValueError(f"{self._plog} Configuration '{dict_key}' must be a dict")
 
-        for collection_mandatory in ['roles', 'regs']:
-            if self.info[collection_mandatory].__len__() < 1:
-                raise ValueError(f"{self._plog} Configuration '{collection_mandatory}' must have at least one element")
+        if self.info['roles'].__len__() < 1:
+            raise ValueError(f"{self._plog} Configuration 'roles' must have at least one element")
+        if not self.CUSTOM_PARSING and self.info['regs'].__len__() < 1:
+            raise ValueError(f"{self._plog} Configuration 'regs' must have at least one element")
 
         for role_name in self.info['roles'].keys():
             if role_name not in BleRole.ROLE_CLASSES:
@@ -217,6 +219,58 @@ class BleDevice(object):
             # Creating entries in ble service to enable/disable options
             DbusBleService.get().register_role_service(role_service)
         logging.debug(f"{self._plog} initialized")
+
+    def _create_indexed_role_service(self, role_type: str, index: int, device_name: str = None, config: dict = None):
+        """
+        Create a role service for a specific slot index, producing a unique D-Bus
+        service name like com.victronenergy.tank.{dev_prefix}_{mac}_{index:02d}.
+
+        Use this for devices that expose multiple instances of the same role type
+        (e.g. multi-tank monitors). The service is stored in _role_services keyed
+        by '{role_type}_{index:02d}' and registered with DbusBleService.
+
+        Returns the DbusRoleService, or None on failure.
+        """
+        key = f'{role_type}_{index:02d}'
+        if key in self._role_services:
+            return self._role_services[key]
+
+        role_cls = BleRole.get_class(role_type)
+        if role_cls is None:
+            logging.error(f"{self._plog} unknown role type {role_type!r}")
+            return None
+
+        role = role_cls(config or {})
+        try:
+            role.check_configuration()
+        except ValueError as e:
+            logging.error(f"{self._plog} ignoring {role_type} index {index}: {e}")
+            return None
+
+        base_dev_id = self.info['dev_id']
+        self.info['dev_id'] = f"{base_dev_id}_{index:02d}"
+
+        role_service = DbusRoleService(self, role)
+        role_service.load_settings()
+
+        if device_name:
+            role_service['DeviceName'] = device_name
+
+        self._role_services[key] = role_service
+        DbusBleService.get().register_role_service(role_service)
+
+        self.info['dev_id'] = base_dev_id
+        logging.info(f"{self._plog} created indexed {role_type} service [{index:02d}]")
+        return role_service
+
+    def _is_indexed_role_enabled(self, role_type: str, index: int) -> bool:
+        """Check if a specific indexed role service is enabled in the GUI."""
+        key = f'{role_type}_{index:02d}'
+        role_service = self._role_services.get(key)
+        if role_service is None:
+            return False
+        enabled_path = f"/Devices/{role_service.get_dev_id()}_{role_type}/Enabled"
+        return bool(DbusBleService.get()._get_value(enabled_path))
 
     def _load_str(self, reg: dict, manufacturer_data: bytes) -> str:
         # Check there is enough data

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_mopeka.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_mopeka.py
@@ -288,7 +288,11 @@ class BleDeviceMopeka(BleDevice):
 
     def _get_low_battery_state(self, role_service: DbusRoleService) -> int:
         # Percentage based on 3 volt CR2032 battery
-        if (battery_voltage := role_service.get('BatteryVoltage', None)) is None:
+        try:
+            battery_voltage = role_service['BatteryVoltage']
+        except (KeyError, TypeError):
+            return 0
+        if battery_voltage is None:
             return 0
         battery_percentage = max(0, min(100, ((battery_voltage - 2.2) / 0.65) * 100))
         return int(battery_percentage < 15)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_mopeka.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_mopeka.py
@@ -36,15 +36,15 @@ class BleDeviceMopeka(BleDevice):
                     },
                 }
             ],
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         },
         4: {
             'device_name': 'Mopeka Pro200',
-            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}}
         },
         5: {
             'device_name': 'Mopeka H20',
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         },
         8: {
             'device_name': 'Mopeka PPB',
@@ -59,7 +59,7 @@ class BleDeviceMopeka(BleDevice):
                     },
                 }
             ],
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         },
         9: {
             'device_name': 'Mopeka PPC',
@@ -74,15 +74,15 @@ class BleDeviceMopeka(BleDevice):
                     },
                 }
             ],
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         },
         10: {
             'device_name': 'Mopeka TDB',
-            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}}
         },
         11: {
             'device_name': 'Mopeka TDC',
-            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {'flags': ['TANK_FLAG_TOPDOWN']}}
         },
         12: {
             'device_name': 'Mopeka Univ',
@@ -97,7 +97,7 @@ class BleDeviceMopeka(BleDevice):
                     },
                 }
             ],
-            'roles': {'tank': {}, 'temperature': {}, 'movement': {}}
+            'roles': {'tank': {}}
         }
     }
 
@@ -157,7 +157,7 @@ class BleDeviceMopeka(BleDevice):
                     'bits': 7,
                     'scale': 1,
                     'bias': -40,
-                    'roles': ['temperature'],
+                    'roles': ['tank'],
                     # .format	= &veUnitCelsius1Dec,
                 },
                 {
@@ -191,7 +191,7 @@ class BleDeviceMopeka(BleDevice):
                     'type': VE_SN8,
                     'offset': 8,
                     'scale': 1024,
-                    'roles': ['movement'],
+                    'roles': [None],
                     # .format	= &veUnitG2Dec,
                 },
                 {
@@ -199,7 +199,7 @@ class BleDeviceMopeka(BleDevice):
                     'type': VE_SN8,
                     'offset': 9,
                     'scale': 1024,
-                    'roles': ['movement'],
+                    'roles': [None],
                     # .format	= &veUnitG2Dec,
                 }
             ],
@@ -227,16 +227,20 @@ class BleDeviceMopeka(BleDevice):
     def _get_scale_butane(self, butane_ratio: int, temperature: float) -> float:
         """
         Calculate the butane scale factor based on temperature and user-defined ratio.
+        Matches C: mopeka_coefs_butane[0] * r + mopeka_coefs_butane[1] * r * temp
         """
-        return self._COEFS_BUTANE[0] + self._COEFS_BUTANE[1] * temperature * (butane_ratio / 100.0)
+        r = butane_ratio / 100.0
+        return self._COEFS_BUTANE[0] * r + self._COEFS_BUTANE[1] * r * temperature
 
     def update_data(self, role_service: DbusRoleService, sensor_data: dict):
         """
-        Check for presence of extension bit on certain hardware/firmware saturates at 16383.
-        When extension bit is set, the raw_value resolution changes to 4us with 16384 us offset.
-        Thus old sensors and firmware still have 0 to 16383 us range with 1us, and new
-        versions add the range 16384 us to 81916 us with 4 us resolution.
+        Scale the ultrasonic RawValue into centimetres using temperature-dependent
+        polynomial coefficients.  Mirrors the C implementation's mopeka_xlate_level
+        which is an xlate callback on the RawValue register (tank role only).
         """
+        if role_service.ble_role.NAME != 'tank':
+            return
+
         if (temperature := sensor_data.get('Temperature', None)) is None:
             logging.warning(f"{self._plog} can not update sensor data, missing temperature value")
             return

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_safiery.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_safiery.py
@@ -105,7 +105,11 @@ class BleDeviceSafiery(BleDevice):
         return True
 
     def _get_low_battery_state(self, role_service: DbusRoleService) -> int:
-        if (battery_voltage := role_service.get('BatteryVoltage', None)) is None:
+        try:
+            battery_voltage = role_service['BatteryVoltage']
+        except (KeyError, TypeError):
+            return 0
+        if battery_voltage is None:
             return 0
         # Percentage based on 3 volt CR2477 battery
         battery_percentage = max(0, min(100, ((battery_voltage - 2.2) / 0.65) * 100))

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -33,6 +33,7 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
 
     MANUFACTURER_ID = 0x0131  # 305
     PRODUCT_NAME = 'SeeLevel 709-BTP3'
+    DEV_PREFIX = 'seelevel_btp3'
     ROLES = {'tank': {}, 'temperature': {}, 'battery': {}}
 
     # (name, role_type, default_fluid_type)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -105,20 +105,19 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
             logging.warning(f"{self._plog} sensor {sensor_num}: unparseable value {data_str!r}")
             return
 
-        alarm_state = None
         if len(manufacturer_data) >= 14:
             alarm_byte = manufacturer_data[13]
             if ord('0') <= alarm_byte <= ord('9'):
-                alarm_state = alarm_byte - ord('0')
+                hw_alarm = alarm_byte - ord('0')
+                if hw_alarm > 0:
+                    logging.debug(f"{self._plog} sensor {sensor_num}: hardware alarm {hw_alarm}")
 
         if role_type == 'tank':
             level = max(0, min(100, sensor_value))
             sensor_data = self._build_tank_sensor_data(level, role_service)
-
-            if alarm_state is not None:
-                sensor_data['/Alarms/Low/State'] = int(alarm_state > 0)
-
             self._update_dbus_data(role_service, sensor_data)
+            for alarm in role_service.ble_role.info.get('alarms', []):
+                role_service.update_alarm(alarm)
 
         elif role_type == 'temperature':
             temp_c = round((sensor_value - 32.0) * 5.0 / 9.0, 1)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -126,6 +126,7 @@ class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
                 'Temperature': temp_c,
                 'Status': 0,
             }
+            role_service.ble_role.update_data(role_service, sensor_data)
             self._update_dbus_data(role_service, sensor_data)
 
         elif role_type == 'battery':

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp3.py
@@ -1,0 +1,139 @@
+from seelevel_common import BleDeviceSeeLevel
+import logging
+
+
+class BleDeviceSeeLevelBTP3(BleDeviceSeeLevel):
+    """
+    SeeLevel 709-BTP3 (Cypress) tank/temperature/battery monitor.
+
+    Each advertisement reports a single sensor. The same BLE MAC sends
+    advertisements for different sensor numbers over time, so services
+    are created lazily as new sensor numbers appear.
+
+    Byte layout (14 bytes):
+        0-2: Coach ID (24-bit, little-endian)
+        3:   Sensor number (0-13)
+        4-6: Sensor data (3 ASCII chars: "OPN", "ERR", or numeric)
+        7-9: Volume in gallons (3 ASCII chars)
+       10-12: Total capacity in gallons (3 ASCII chars)
+        13:  Alarm state (ASCII digit '0'-'9')
+
+    Sensor number mapping:
+        0: Fresh Water (tank)     7: Temp (temperature)
+        1: Toilet Water (tank)    8: Temp 2 (temperature)
+        2: Wash Water (tank)      9: Temp 3 (temperature)
+        3: LPG (tank)            10: Temp 4 (temperature)
+        4: LPG 2 (tank)          11: Chemical (tank)
+        5: Galley Water (tank)   12: Chemical 2 (tank)
+        6: Galley Water 2 (tank) 13: Battery (battery)
+
+    Cf.
+    - https://github.com/TechBlueprints/victron-seelevel-python
+    """
+
+    MANUFACTURER_ID = 0x0131  # 305
+    PRODUCT_NAME = 'SeeLevel 709-BTP3'
+    ROLES = {'tank': {}, 'temperature': {}, 'battery': {}}
+
+    # (name, role_type, default_fluid_type)
+    SENSORS = {
+        0:  ("Fresh Water", "tank", 1),
+        1:  ("Toilet Water", "tank", 5),
+        2:  ("Wash Water", "tank", 2),
+        3:  ("LPG", "tank", 8),
+        4:  ("LPG 2", "tank", 8),
+        5:  ("Galley Water", "tank", 2),
+        6:  ("Galley Water 2", "tank", 2),
+        7:  ("Temp", "temperature", None),
+        8:  ("Temp 2", "temperature", None),
+        9:  ("Temp 3", "temperature", None),
+        10: ("Temp 4", "temperature", None),
+        11: ("Chemical", "tank", 0),
+        12: ("Chemical 2", "tank", 0),
+        13: ("Voltage", "battery", None),
+    }
+
+    def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
+        if len(manufacturer_data) < 7:
+            return False
+        sensor_num = manufacturer_data[3]
+        return sensor_num in self.SENSORS
+
+    def init(self):
+        self._load_configuration()
+        logging.debug(f"{self._plog} initialized (services created on demand)")
+
+    def handle_manufacturer_data(self, manufacturer_data: bytes):
+        sensor_num = manufacturer_data[3]
+        sensor_info = self.SENSORS.get(sensor_num)
+        if sensor_info is None:
+            return
+
+        name, role_type, fluid_type = sensor_info
+        if role_type is None:
+            return
+
+        key = f'{role_type}_{sensor_num:02d}'
+
+        if key not in self._role_services:
+            role_service = self._create_indexed_role_service(
+                role_type, sensor_num, device_name=f"SeeLevel {name}")
+            if role_service is None:
+                return
+            if role_type == 'tank':
+                if fluid_type is not None and role_service['FluidType'] == 0:
+                    role_service['FluidType'] = fluid_type
+                if role_service['Capacity'] == 0.2:
+                    role_service['Capacity'] = 0.0
+        else:
+            role_service = self._role_services[key]
+
+        if not self._is_indexed_role_enabled(role_type, sensor_num):
+            return
+
+        data_str = manufacturer_data[4:7].decode('ascii', errors='ignore').strip()
+
+        if data_str == "OPN":
+            return
+        if data_str == "ERR":
+            self._set_error_status(role_service)
+            return
+
+        try:
+            sensor_value = int(data_str)
+        except ValueError:
+            logging.warning(f"{self._plog} sensor {sensor_num}: unparseable value {data_str!r}")
+            return
+
+        alarm_state = None
+        if len(manufacturer_data) >= 14:
+            alarm_byte = manufacturer_data[13]
+            if ord('0') <= alarm_byte <= ord('9'):
+                alarm_state = alarm_byte - ord('0')
+
+        if role_type == 'tank':
+            level = max(0, min(100, sensor_value))
+            sensor_data = self._build_tank_sensor_data(level, role_service)
+
+            if alarm_state is not None:
+                sensor_data['/Alarms/Low/State'] = int(alarm_state > 0)
+
+            self._update_dbus_data(role_service, sensor_data)
+
+        elif role_type == 'temperature':
+            temp_c = round((sensor_value - 32.0) * 5.0 / 9.0, 1)
+            sensor_data = {
+                'Temperature': temp_c,
+                'Status': 0,
+            }
+            self._update_dbus_data(role_service, sensor_data)
+
+        elif role_type == 'battery':
+            voltage = sensor_value / 10.0
+            sensor_data = {
+                '/Dc/0/Voltage': voltage,
+                'Status': 0,
+            }
+            self._update_dbus_data(role_service, sensor_data)
+
+        role_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -21,6 +21,7 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
 
     MANUFACTURER_ID = 0x0CC0  # 3264
     PRODUCT_NAME = 'SeeLevel 709-BTP7'
+    DEV_PREFIX = 'seelevel_btp7'
     ROLES = {'tank': {}, 'battery': {}}
 
     TANK_SLOTS = [

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -71,6 +71,8 @@ class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
 
             sensor_data = self._build_tank_sensor_data(level, role_service)
             self._update_dbus_data(role_service, sensor_data)
+            for alarm in role_service.ble_role.info.get('alarms', []):
+                role_service.update_alarm(alarm)
             role_service.connect()
 
         if self._is_indexed_role_enabled('battery', 8):

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_seelevel_btp7.py
@@ -1,0 +1,84 @@
+from seelevel_common import BleDeviceSeeLevel
+import logging
+
+
+class BleDeviceSeeLevelBTP7(BleDeviceSeeLevel):
+    """
+    SeeLevel 709-BTP7 tank/battery monitor.
+
+    Broadcasts 8 tank levels (0-100%) and battery voltage in a single
+    14-byte manufacturer data advertisement.
+
+    Byte layout:
+        0-2: Coach ID (24-bit, little-endian)
+        3-10: Tank levels (1 byte each, 0-100 = %, >100 = error code)
+              Slots: Fresh, Wash, Toilet, Fresh2, Wash2, Toilet2, Wash3, LPG
+        11:  Battery voltage * 10 (e.g. 120 = 12.0V)
+
+    Cf.
+    - https://github.com/TechBlueprints/victron-seelevel-python
+    """
+
+    MANUFACTURER_ID = 0x0CC0  # 3264
+    PRODUCT_NAME = 'SeeLevel 709-BTP7'
+    ROLES = {'tank': {}, 'battery': {}}
+
+    TANK_SLOTS = [
+        ("Fresh Water", 1),      # slot 0: FluidType = Fresh water
+        ("Wash Water", 2),       # slot 1: FluidType = Waste water
+        ("Toilet Water", 5),     # slot 2: FluidType = Black water
+        ("Fresh Water 2", 1),    # slot 3
+        ("Wash Water 2", 2),     # slot 4
+        ("Toilet Water 2", 5),   # slot 5
+        ("Wash Water 3", 2),     # slot 6
+        ("LPG", 8),             # slot 7: FluidType = LPG
+    ]
+
+    def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
+        return len(manufacturer_data) >= 12
+
+    def init(self):
+        self._load_configuration()
+
+        for slot, (tank_name, fluid_type) in enumerate(self.TANK_SLOTS):
+            role_service = self._create_indexed_role_service(
+                'tank', slot, device_name=f"SeeLevel {tank_name}")
+            if role_service:
+                if role_service['FluidType'] == 0:
+                    role_service['FluidType'] = fluid_type
+                if role_service['Capacity'] == 0.2:
+                    role_service['Capacity'] = 0.0
+
+        self._create_indexed_role_service(
+            'battery', 8, device_name="SeeLevel Voltage")
+
+        logging.debug(f"{self._plog} initialized {len(self._role_services)} service slots")
+
+    def handle_manufacturer_data(self, manufacturer_data: bytes):
+        for slot in range(8):
+            if not self._is_indexed_role_enabled('tank', slot):
+                continue
+
+            role_service = self._role_services.get(f'tank_{slot:02d}')
+            if role_service is None:
+                continue
+
+            level = manufacturer_data[slot + 3]
+
+            if level > 100:
+                self._set_error_status(role_service, level)
+                continue
+
+            sensor_data = self._build_tank_sensor_data(level, role_service)
+            self._update_dbus_data(role_service, sensor_data)
+            role_service.connect()
+
+        if self._is_indexed_role_enabled('battery', 8):
+            battery_service = self._role_services.get('battery_08')
+            if battery_service and len(manufacturer_data) >= 12:
+                voltage = manufacturer_data[11] / 10.0
+                self._update_dbus_data(battery_service, {
+                    '/Dc/0/Voltage': voltage,
+                    'Status': 0,
+                })
+                battery_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_battery.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_battery.py
@@ -1,0 +1,21 @@
+from ble_role import BleRole
+
+
+class BleRoleBattery(BleRole):
+    """
+    Battery voltage monitor role class.
+    Device claiming this role must provide a '/Dc/0/Voltage' item.
+    """
+
+    NAME = 'battery'
+
+    def __init__(self, config: dict = None):
+        super().__init__()
+
+        self.info.update(
+            {
+                'name': 'battery',
+                'dev_instance': 50,
+                'settings': [],
+            },
+        )

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_tank.py
@@ -228,7 +228,7 @@ class BleRoleTank(BleRole):
         elif level > 1:
             level = 1
 
-        for i in range(1, len(self._shape_map)):
+        for i in range(1, len(self._shape_map) if self._shape_map else 0):
             if self._shape_map[i][0] >= level:
                 lev_1 = float(self._shape_map[i-1][0])
                 lev_2 = float(self._shape_map[i][0])

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -19,11 +19,16 @@ from logger import setup_logging
 from collections.abc import MutableMapping
 import threading
 import time
-from conf import SCAN_TIMEOUT, SCAN_SLEEP, IGNORED_DEVICES_TIMEOUT, DEVICE_SERVICES_TIMEOUT, PROCESS_VERSION
+from conf import IGNORED_DEVICES_TIMEOUT, DEVICE_SERVICES_TIMEOUT, PROCESS_VERSION
 from man_id import MAN_NAMES
 
 SNIF_LOGGER = logging.getLogger("sniffer")
 SNIF_LOGGER.propagate = False
+
+SCANNER_INITIAL_BACKOFF = 2
+SCANNER_MAX_BACKOFF = 60
+SCANNER_MAX_PASSIVE_RETRIES = 5
+SCANNER_ACTIVE_CYCLE_DURATION = 15
 
 # OrPattern tuples for passive scanning via BlueZ AdvertisementMonitor1.
 # Passive scanning avoids calling StartDiscovery, which eliminates scan
@@ -117,128 +122,268 @@ class DbusBleSensors(object):
             self._adapters.remove(name)
             logging.info(f"{name}: adapter removed")
 
-    async def _scan(self, adapter: str):
-        def _scan_callback(device, advertisement_data):
-            dev_mac = "".join(device.address.split(':')).lower()
-            if dev_mac in self._ignored_mac:
-                # Ignoring devices already evaluated
-                return
+    def _process_advertisement(self, device, advertisement_data):
+        """Process a single BLE advertisement (called from scan_loop on the main thread)."""
+        dev_mac = "".join(device.address.split(':')).lower()
+        if dev_mac in self._ignored_mac:
+            return
 
-            plog = f"{dev_mac} - {device.name}:"
-            logging.debug(f"{plog} received advertisement {advertisement_data!r}")
-            if advertisement_data.manufacturer_data is None or len(advertisement_data.manufacturer_data) < 1:
-                logging.info(f"{plog} ignoring, device without manufacturer data")
-                self._ignored_mac[dev_mac] = True
-                return
+        plog = f"{dev_mac} - {device.name}:"
+        logging.debug(f"{plog} received advertisement {advertisement_data!r}")
+        if advertisement_data.manufacturer_data is None or len(advertisement_data.manufacturer_data) < 1:
+            logging.info(f"{plog} ignoring, device without manufacturer data")
+            self._ignored_mac[dev_mac] = True
+            return
 
-            # Loop through manufacturer data fields, even though most devices only use one
-            for man_id, man_data in advertisement_data.manufacturer_data.items():
-                if dev_mac not in self._known_mac:
-                    # Snif new device advertising data
-                    self.snif_data(man_id, man_data)
+        for man_id, man_data in advertisement_data.manufacturer_data.items():
+            if dev_mac not in self._known_mac:
+                self.snif_data(man_id, man_data)
 
-                    # Get device class from manufacturer id
-                    device_class = BleDevice.DEVICE_CLASSES.get(man_id, None)
-                    if device_class is None:
-                        logging.info(f"{plog} ignoring data {man_data!r}, no device configuration class for manufacturer {man_id!r}")
-                        self._ignored_mac[dev_mac] = True
-                        continue
+                device_class = BleDevice.DEVICE_CLASSES.get(man_id, None)
+                if device_class is None:
+                    logging.info(f"{plog} ignoring data {man_data!r}, no device configuration class for manufacturer {man_id!r}")
+                    self._ignored_mac[dev_mac] = True
+                    continue
 
-                    # Run device specific parsing
-                    logging.info(f"{plog} initializing device with class {device_class}")
-                    try:
-                        dev_instance = device_class(dev_mac)
-                        if not dev_instance.check_manufacturer_data(man_data):
-                            raise ValueError(f"{plog} ignoring data {man_data!r}, manufacturer data check failed")
-                        dev_instance.configure(man_data)
-                        dev_instance.init()
-                        self._known_mac[dev_mac] = dev_instance
-                    except Exception as e:
-                        logging.exception(f"{plog} ignoring data {man_data!r}, an error occurred during device initialization:")
-                        continue
-                else:
-                    dev_instance = self._known_mac[dev_mac]
+                logging.info(f"{plog} initializing device with class {device_class}")
+                try:
+                    dev_instance = device_class(dev_mac)
+                    if not dev_instance.check_manufacturer_data(man_data):
+                        raise ValueError(f"{plog} ignoring data {man_data!r}, manufacturer data check failed")
+                    dev_instance.configure(man_data)
+                    dev_instance.init()
+                    self._known_mac[dev_mac] = dev_instance
+                except Exception as e:
+                    logging.exception(f"{plog} ignoring data {man_data!r}, an error occurred during device initialization:")
+                    continue
+            else:
+                dev_instance = self._known_mac[dev_mac]
 
-                # Parsing data
-                logging.info(f"{plog} received manufacturer data: {man_data!r}")
-                if dev_instance.check_manufacturer_data(man_data):
-                    dev_instance.handle_manufacturer_data(man_data)
-                else:
-                    logging.info(f"{plog} ignoring manufacturer data due to data check")
+            logging.info(f"{plog} received manufacturer data: {man_data!r}")
+            if dev_instance.check_manufacturer_data(man_data):
+                dev_instance.handle_manufacturer_data(man_data)
+            else:
+                logging.info(f"{plog} ignoring manufacturer data due to data check")
 
-        logging.debug(f"{adapter}: Scanning ...")
-        try:
-            results = await self._run_passive_scan(adapter)
-            for device, ad_data in results:
-                _scan_callback(device, ad_data)
-            logging.debug(f"{adapter}: Scan finished (passive, {len(results)} advertisements)")
-        except Exception as e_passive:
-            logging.warning(f"{adapter}: Passive scan failed ({e_passive}), falling back to active scan")
+    def _start_scanners(self):
+        """Start passive BleakScanners in a background thread.
+
+        We run scanners in a dedicated thread with a standard asyncio event
+        loop because the main thread uses gbulb (GLib-backed asyncio) which
+        is incompatible with dbus-fast's method-call dispatch needed for
+        passive scanning via AdvertisementMonitor1.
+
+        Each adapter gets a persistent passive scanner.  If a scanner fails
+        to start (e.g. EBUSY because another service is adjusting scan
+        parameters), that adapter retries with exponential backoff."""
+        self._scan_buffer = []
+        self._scan_buffer_lock = threading.Lock()
+        self._scanner_stop = threading.Event()
+
+        def _thread_main():
+            policy = asyncio.DefaultEventLoopPolicy()
+            loop = policy.new_event_loop()
+            asyncio.set_event_loop(loop)
             try:
-                async with bleak.BleakScanner(
-                    detection_callback=_scan_callback,
-                    bluez=dict(adapter=adapter),
-                ) as scanner:
-                    await asyncio.sleep(SCAN_TIMEOUT)
-                logging.debug(f"{adapter}: Scan finished (active fallback)")
+                loop.run_until_complete(self._run_scanners())
             except Exception:
-                logging.exception(f"{adapter}: Scan error")
+                logging.exception("Scanner thread error")
 
-    async def _run_passive_scan(self, adapter: str):
-        """Run passive BleakScanner in a dedicated thread with a standard asyncio
-        event loop.  BlueZ AdvertisementMonitor1 requires incoming D-Bus method
-        calls (DeviceFound) from bluetoothd to the client.  Bleak handles these
-        via dbus-fast, but the callbacks are never delivered when the process
-        uses a gbulb GLib event loop.  Running the scanner in its own thread
-        with asyncio.run() gives dbus-fast a clean event loop.
+        self._scanner_thread = threading.Thread(target=_thread_main, daemon=True)
+        self._scanner_thread.start()
 
-        IMPORTANT: The main process sets GLibEventLoopPolicy as the global
-        asyncio policy. asyncio.run() in a thread would inherit that policy,
-        creating another gbulb loop.  We override to DefaultEventLoopPolicy
-        in the worker thread so dbus-fast gets a real selector-based loop."""
-        results = []
-        scan_error = None
+    @staticmethod
+    async def _power_cycle_adapter(adapter):
+        """Power-cycle a BlueZ adapter to clear corrupted HCI scan state.
 
-        def _worker():
-            nonlocal scan_error
-            asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
-            async def _do_scan():
-                async with bleak.BleakScanner(
-                    detection_callback=lambda d, a: results.append((d, a)),
-                    scanning_mode='passive',
-                    bluez=dict(or_patterns=PASSIVE_SCAN_OR_PATTERNS, adapter=adapter),
-                ) as scanner:
-                    await asyncio.sleep(SCAN_TIMEOUT)
-            try:
-                asyncio.run(_do_scan())
-            except Exception as exc:
-                scan_error = exc
+        When the C-based dbus-ble-sensors service uses raw HCI sockets with
+        legacy scan commands (0x200B/0x200C) on a BT 5.x adapter, BlueZ
+        cannot disable the orphaned scan because it sends extended commands
+        (0x2041/0x2042) which the controller rejects (Command Disallowed /
+        EBUSY).  Power-cycling via D-Bus triggers a proper HCI Reset that
+        clears all controller state."""
+        from dbus_fast.aio import MessageBus
+        from dbus_fast import BusType, Variant
 
-        await asyncio.get_event_loop().run_in_executor(None, _worker)
-        if scan_error is not None:
-            raise scan_error
-        return results
+        adapter_path = f'/org/bluez/{adapter}'
+        logging.info(f"{adapter}: power-cycling to clear HCI state")
+        bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+        try:
+            introspection = await bus.introspect('org.bluez', adapter_path)
+            proxy = bus.get_proxy_object('org.bluez', adapter_path, introspection)
+            props = proxy.get_interface('org.freedesktop.DBus.Properties')
+            await props.call_set('org.bluez.Adapter1', 'Powered', Variant('b', False))
+            await asyncio.sleep(1)
+            await props.call_set('org.bluez.Adapter1', 'Powered', Variant('b', True))
+            await asyncio.sleep(2)
+            logging.info(f"{adapter}: power-cycle complete")
+        except Exception as e:
+            logging.warning(f"{adapter}: power-cycle failed: {e}")
+        finally:
+            bus.disconnect()
+
+    async def _run_scanners(self):
+        """Run persistent BleakScanners with per-adapter state tracking.
+
+        Each adapter starts in passive mode.  On failure, retries with
+        exponential backoff up to MAX_PASSIVE_RETRIES times.  After that,
+        power-cycles the adapter via D-Bus to clear any corrupted HCI scan
+        state (e.g. from the C-based dbus-ble-sensors service using raw HCI
+        sockets with legacy commands on a BT 5.x adapter).  If passive
+        scanning still fails after the power-cycle, falls back to one
+        active scan cycle before returning to passive.
+        Mode transitions are logged at INFO level per adapter."""
+        INITIAL_BACKOFF = SCANNER_INITIAL_BACKOFF
+        MAX_BACKOFF = SCANNER_MAX_BACKOFF
+        MAX_PASSIVE_RETRIES = SCANNER_MAX_PASSIVE_RETRIES
+        ACTIVE_CYCLE_DURATION = SCANNER_ACTIVE_CYCLE_DURATION
+
+        def _detection_callback(device, adv_data):
+            with self._scan_buffer_lock:
+                self._scan_buffer.append((device, adv_data))
+
+        adapter_state = {}
+
+        def _state(adapter):
+            if adapter not in adapter_state:
+                adapter_state[adapter] = {
+                    'mode': 'passive',
+                    'scanner': None,
+                    'retries': 0,
+                    'backoff': INITIAL_BACKOFF,
+                    'retry_at': 0.0,
+                    'logged_mode': None,
+                    'power_cycled': False,
+                }
+            return adapter_state[adapter]
+
+        def _log_mode(adapter, st, reason=''):
+            if st['logged_mode'] != st['mode']:
+                suffix = f' ({reason})' if reason else ''
+                logging.info(f"{adapter}: scanning mode: {st['mode']}{suffix}")
+                st['logged_mode'] = st['mode']
+
+        while not self._scanner_stop.is_set():
+            now = asyncio.get_event_loop().time()
+
+            for adapter in self._adapters:
+                st = _state(adapter)
+
+                if st['scanner'] is not None:
+                    continue
+                if now < st['retry_at']:
+                    continue
+
+                if st['mode'] == 'passive':
+                    try:
+                        scanner = bleak.BleakScanner(
+                            detection_callback=_detection_callback,
+                            scanning_mode='passive',
+                            bluez=dict(or_patterns=PASSIVE_SCAN_OR_PATTERNS, adapter=adapter),
+                        )
+                        await scanner.start()
+                        st['scanner'] = scanner
+                        st['retries'] = 0
+                        st['backoff'] = INITIAL_BACKOFF
+                        _log_mode(adapter, st)
+                    except Exception as e:
+                        st['retries'] += 1
+                        delay = st['backoff']
+                        st['backoff'] = min(delay * 2, MAX_BACKOFF)
+                        st['retry_at'] = now + delay
+
+                        if st['retries'] >= MAX_PASSIVE_RETRIES:
+                            if not st['power_cycled']:
+                                logging.warning(
+                                    f"{adapter}: passive scan failed {st['retries']} times, "
+                                    f"power-cycling adapter to clear HCI state"
+                                )
+                                await self._power_cycle_adapter(adapter)
+                                st['power_cycled'] = True
+                                st['retries'] = 0
+                                st['backoff'] = INITIAL_BACKOFF
+                                st['retry_at'] = 0.0
+                                st['logged_mode'] = None
+                            else:
+                                logging.warning(
+                                    f"{adapter}: passive scan still failing after power-cycle, "
+                                    f"falling back to active for one cycle"
+                                )
+                                st['mode'] = 'active'
+                                st['retry_at'] = 0.0
+                        else:
+                            logging.warning(
+                                f"{adapter}: passive scan start failed ({e}), "
+                                f"retry {st['retries']}/{MAX_PASSIVE_RETRIES} in {delay:.0f}s"
+                            )
+
+                elif st['mode'] == 'active':
+                    try:
+                        scanner = bleak.BleakScanner(
+                            detection_callback=_detection_callback,
+                            bluez=dict(adapter=adapter),
+                        )
+                        await scanner.start()
+                        _log_mode(adapter, st, reason='fallback')
+
+                        for _ in range(ACTIVE_CYCLE_DURATION):
+                            if self._scanner_stop.is_set():
+                                break
+                            await asyncio.sleep(1)
+
+                        await scanner.stop()
+                    except bleak.exc.BleakDBusError as e:
+                        if "InProgress" in str(e):
+                            logging.debug(f"{adapter}: active scan InProgress, will retry")
+                        else:
+                            logging.warning(f"{adapter}: active scan error: {e}")
+                    except Exception as e:
+                        logging.warning(f"{adapter}: active scan error: {e}")
+
+                    st['mode'] = 'passive'
+                    st['retries'] = 0
+                    st['backoff'] = INITIAL_BACKOFF
+                    st['retry_at'] = 0.0
+                    st['power_cycled'] = False
+                    logging.info(f"{adapter}: active cycle complete, retrying passive")
+
+            await asyncio.sleep(1)
+
+        for adapter, st in adapter_state.items():
+            if st['scanner'] is not None:
+                try:
+                    await st['scanner'].stop()
+                    logging.info(f"{adapter}: scanner stopped")
+                except Exception:
+                    pass
 
     async def scan_loop(self):
+        DRAIN_INTERVAL = 5
+
         while True:
-            # Start scans on all adapters
             if len(self._adapters) < 1:
                 logging.warning("Waiting for a bluetooth adapter...")
                 await asyncio.sleep(5)
                 continue
-            scan_tasks = [asyncio.create_task(self._scan(adapter)) for adapter in self._adapters]
-            await asyncio.gather(*scan_tasks)
 
-            # Clean known/ignored device lists
+            if not hasattr(self, '_scanner_thread'):
+                self._start_scanners()
+                await asyncio.sleep(DRAIN_INTERVAL)
+
+            with self._scan_buffer_lock:
+                results = self._scan_buffer[:]
+                self._scan_buffer.clear()
+
+            for device, ad_data in results:
+                try:
+                    self._process_advertisement(device, ad_data)
+                except Exception:
+                    logging.exception(f"Error processing advertisement from {device.address}")
+
             self._known_mac.prune()
             self._ignored_mac.prune()
 
-            # Wait before next scan if needed
-            if self._dbus_ble_service.get_continuous_scan():
-                logging.debug(f"{self._adapters}: continuous scan on, restarting scan immediately")
-            else:
-                logging.debug(f"{self._adapters}: continuous scan off, pausing for {SCAN_SLEEP!r} seconds")
-                await asyncio.sleep(SCAN_SLEEP)
+            await asyncio.sleep(DRAIN_INTERVAL)
 
     def snif_data(self, man_id: int, man_data: bytes):
         """

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -13,6 +13,7 @@ from ble_device import BleDevice
 from ble_role import BleRole
 from dbus_ble_service import DbusBleService
 import bleak
+from bleak.assigned_numbers import AdvertisementDataType
 import gbulb
 from logger import setup_logging
 from collections.abc import MutableMapping
@@ -22,6 +23,22 @@ from man_id import MAN_NAMES
 
 SNIF_LOGGER = logging.getLogger("sniffer")
 SNIF_LOGGER.propagate = False
+
+# OrPattern tuples for passive scanning via BlueZ AdvertisementMonitor1.
+# Passive scanning avoids calling StartDiscovery, which eliminates scan
+# contention (InProgress errors) when multiple BLE services share the
+# adapter.  Each tuple is (offset, AD_type, value) matching common LE
+# Flags byte values so virtually all advertising devices are captured.
+# Requires BlueZ >= 5.56 with --experimental and kernel >= 5.10.
+PASSIVE_SCAN_OR_PATTERNS = [
+    (0, AdvertisementDataType.FLAGS, bytes([0x02])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x06])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x1a])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x04])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x05])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x0e])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x1e])),
+]
 
 class DbusBleSensors(object):
     """
@@ -150,11 +167,24 @@ class DbusBleSensors(object):
 
         logging.debug(f"{adapter}: Scanning ...")
         try:
-            async with bleak.BleakScanner(adapter=adapter, detection_callback=_scan_callback) as scanner:
+            async with bleak.BleakScanner(
+                detection_callback=_scan_callback,
+                scanning_mode='passive',
+                bluez=dict(or_patterns=PASSIVE_SCAN_OR_PATTERNS, adapter=adapter),
+            ) as scanner:
                 await asyncio.sleep(SCAN_TIMEOUT)
-            logging.debug(f"{adapter}: Scan finished")
-        except Exception:
-            logging.exception(f"{adapter}: Scan error")
+            logging.debug(f"{adapter}: Scan finished (passive)")
+        except Exception as e_passive:
+            logging.warning(f"{adapter}: Passive scan failed ({e_passive}), falling back to active scan")
+            try:
+                async with bleak.BleakScanner(
+                    detection_callback=_scan_callback,
+                    bluez=dict(adapter=adapter),
+                ) as scanner:
+                    await asyncio.sleep(SCAN_TIMEOUT)
+                logging.debug(f"{adapter}: Scan finished (active fallback)")
+            except Exception:
+                logging.exception(f"{adapter}: Scan error")
 
     async def scan_loop(self):
         while True:

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -33,18 +33,27 @@ SCANNER_ACTIVE_CYCLE_DURATION = 15
 # OrPattern tuples for passive scanning via BlueZ AdvertisementMonitor1.
 # Passive scanning avoids calling StartDiscovery, which eliminates scan
 # contention (InProgress errors) when multiple BLE services share the
-# adapter.  Each tuple is (offset, AD_type, value) matching common LE
-# Flags byte values so virtually all advertising devices are captured.
+# adapter.  Each tuple is (offset, AD_type, value) where AD_type is the
+# BLE AD type code and value is a prefix to match.
 # Requires BlueZ >= 5.56 with --experimental and kernel >= 5.10.
+#
+# Only Flags-based patterns are used here.  Manufacturer-data patterns
+# (AD type 0xFF) crash BlueZ 5.72 / kernel 6.12 with heap corruption
+# (free(): invalid next size).  To catch devices that omit Flags entirely
+# (e.g. Mopeka sensors), a periodic active scan with DuplicateData=True
+# is run alongside the passive scanner — see _run_nondiscoverable_scan().
 PASSIVE_SCAN_OR_PATTERNS = [
     (0, AdvertisementDataType.FLAGS, bytes([0x02])),
-    (0, AdvertisementDataType.FLAGS, bytes([0x06])),
-    (0, AdvertisementDataType.FLAGS, bytes([0x1a])),
     (0, AdvertisementDataType.FLAGS, bytes([0x04])),
     (0, AdvertisementDataType.FLAGS, bytes([0x05])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x06])),
     (0, AdvertisementDataType.FLAGS, bytes([0x0e])),
+    (0, AdvertisementDataType.FLAGS, bytes([0x1a])),
     (0, AdvertisementDataType.FLAGS, bytes([0x1e])),
 ]
+
+NONDISCOVERABLE_SCAN_INTERVAL = 30
+NONDISCOVERABLE_SCAN_DURATION = 15
 
 class DbusBleSensors(object):
     """
@@ -155,6 +164,7 @@ class DbusBleSensors(object):
                     self._known_mac[dev_mac] = dev_instance
                 except Exception as e:
                     logging.exception(f"{plog} ignoring data {man_data!r}, an error occurred during device initialization:")
+                    self._ignored_mac[dev_mac] = True
                     continue
             else:
                 dev_instance = self._known_mac[dev_mac]
@@ -185,7 +195,10 @@ class DbusBleSensors(object):
             loop = policy.new_event_loop()
             asyncio.set_event_loop(loop)
             try:
-                loop.run_until_complete(self._run_scanners())
+                loop.run_until_complete(asyncio.gather(
+                    self._run_scanners(),
+                    self._run_nondiscoverable_scans(),
+                ))
             except Exception:
                 logging.exception("Scanner thread error")
 
@@ -356,6 +369,56 @@ class DbusBleSensors(object):
                     logging.info(f"{adapter}: scanner stopped")
                 except Exception:
                     pass
+
+    async def _run_nondiscoverable_scans(self):
+        """Periodic active scans with DuplicateData=True to detect devices
+        that omit the Flags AD type (e.g. Mopeka sensors advertise only
+        manufacturer data under Nordic's company ID 0x0059 with no Flags).
+
+        These scans run alongside the persistent passive scanners.  If the
+        adapter is busy (InProgress), the scan is silently skipped."""
+        while not self._scanner_stop.is_set():
+            await asyncio.sleep(NONDISCOVERABLE_SCAN_INTERVAL)
+            for adapter in list(self._adapters):
+                try:
+                    nd_results = []
+
+                    def _nd_callback(device, adv_data, _buf=nd_results):
+                        _buf.append((device, adv_data))
+
+                    scanner = bleak.BleakScanner(
+                        detection_callback=_nd_callback,
+                        bluez=dict(
+                            adapter=adapter,
+                            filters={"DuplicateData": True},
+                        ),
+                    )
+                    await scanner.start()
+                    for _ in range(NONDISCOVERABLE_SCAN_DURATION):
+                        if self._scanner_stop.is_set():
+                            break
+                        await asyncio.sleep(1)
+                    await scanner.stop()
+
+                    with self._scan_buffer_lock:
+                        self._scan_buffer.extend(nd_results)
+                    logging.info(
+                        f"{adapter}: nondiscoverable scan finished "
+                        f"({len(nd_results)} advertisements)"
+                    )
+                except bleak.exc.BleakDBusError as e:
+                    if "InProgress" in str(e):
+                        logging.debug(
+                            f"{adapter}: nondiscoverable scan skipped (InProgress)"
+                        )
+                    else:
+                        logging.warning(
+                            f"{adapter}: nondiscoverable scan error: {e}"
+                        )
+                except Exception as e:
+                    logging.warning(
+                        f"{adapter}: nondiscoverable scan error: {e}"
+                    )
 
     async def scan_loop(self):
         DRAIN_INTERVAL = 5

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -11,6 +11,7 @@ from dbus.mainloop.glib import DBusGMainLoop
 from argparse import ArgumentParser
 from ble_device import BleDevice
 from ble_role import BleRole
+from dbus_bus import get_bus
 from dbus_ble_service import DbusBleService
 import bleak
 from bleak.assigned_numbers import AdvertisementDataType
@@ -69,8 +70,7 @@ class DbusBleSensors(object):
     """
 
     def __init__(self):
-        # Get dbus, default is system
-        self._dbus: dbus.Bus = dbus.SessionBus() if 'DBUS_SESSION_BUS_ADDRESS' in os.environ else dbus.SystemBus()
+        self._dbus: dbus.bus.BusConnection = get_bus("org.bluez")
         # Accessor to dbus ble dedicated service (default : com.victronenergy.ble)
         self._dbus_ble_service = DbusBleService()
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -17,6 +17,7 @@ from bleak.assigned_numbers import AdvertisementDataType
 import gbulb
 from logger import setup_logging
 from collections.abc import MutableMapping
+import threading
 import time
 from conf import SCAN_TIMEOUT, SCAN_SLEEP, IGNORED_DEVICES_TIMEOUT, DEVICE_SERVICES_TIMEOUT, PROCESS_VERSION
 from man_id import MAN_NAMES
@@ -167,13 +168,10 @@ class DbusBleSensors(object):
 
         logging.debug(f"{adapter}: Scanning ...")
         try:
-            async with bleak.BleakScanner(
-                detection_callback=_scan_callback,
-                scanning_mode='passive',
-                bluez=dict(or_patterns=PASSIVE_SCAN_OR_PATTERNS, adapter=adapter),
-            ) as scanner:
-                await asyncio.sleep(SCAN_TIMEOUT)
-            logging.debug(f"{adapter}: Scan finished (passive)")
+            results = await self._run_passive_scan(adapter)
+            for device, ad_data in results:
+                _scan_callback(device, ad_data)
+            logging.debug(f"{adapter}: Scan finished (passive, {len(results)} advertisements)")
         except Exception as e_passive:
             logging.warning(f"{adapter}: Passive scan failed ({e_passive}), falling back to active scan")
             try:
@@ -185,6 +183,35 @@ class DbusBleSensors(object):
                 logging.debug(f"{adapter}: Scan finished (active fallback)")
             except Exception:
                 logging.exception(f"{adapter}: Scan error")
+
+    async def _run_passive_scan(self, adapter: str):
+        """Run passive BleakScanner in a dedicated thread with a standard asyncio
+        event loop.  BlueZ AdvertisementMonitor1 requires incoming D-Bus method
+        calls (DeviceFound) from bluetoothd to the client.  Bleak handles these
+        via dbus-fast, but the callbacks are never delivered when the process
+        uses a gbulb GLib event loop.  Running the scanner in its own thread
+        with asyncio.run() gives dbus-fast a clean event loop."""
+        results = []
+        scan_error = None
+
+        def _worker():
+            nonlocal scan_error
+            async def _do_scan():
+                async with bleak.BleakScanner(
+                    detection_callback=lambda d, a: results.append((d, a)),
+                    scanning_mode='passive',
+                    bluez=dict(or_patterns=PASSIVE_SCAN_OR_PATTERNS, adapter=adapter),
+                ) as scanner:
+                    await asyncio.sleep(SCAN_TIMEOUT)
+            try:
+                asyncio.run(_do_scan())
+            except Exception as exc:
+                scan_error = exc
+
+        await asyncio.get_event_loop().run_in_executor(None, _worker)
+        if scan_error is not None:
+            raise scan_error
+        return results
 
     async def scan_loop(self):
         while True:

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -190,12 +190,18 @@ class DbusBleSensors(object):
         calls (DeviceFound) from bluetoothd to the client.  Bleak handles these
         via dbus-fast, but the callbacks are never delivered when the process
         uses a gbulb GLib event loop.  Running the scanner in its own thread
-        with asyncio.run() gives dbus-fast a clean event loop."""
+        with asyncio.run() gives dbus-fast a clean event loop.
+
+        IMPORTANT: The main process sets GLibEventLoopPolicy as the global
+        asyncio policy. asyncio.run() in a thread would inherit that policy,
+        creating another gbulb loop.  We override to DefaultEventLoopPolicy
+        in the worker thread so dbus-fast gets a real selector-based loop."""
         results = []
         scan_error = None
 
         def _worker():
             nonlocal scan_error
+            asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
             async def _do_scan():
                 async with bleak.BleakScanner(
                     detection_callback=lambda d, a: results.append((d, a)),

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -21,6 +21,8 @@ from collections.abc import MutableMapping
 import threading
 import time
 from conf import IGNORED_DEVICES_TIMEOUT, DEVICE_SERVICES_TIMEOUT, PROCESS_VERSION
+
+ADV_LOG_QUIET_PERIOD = 1800  # seconds before re-logging a known device's advertisements
 from man_id import MAN_NAMES
 
 SNIF_LOGGER = logging.getLogger("sniffer")
@@ -81,6 +83,7 @@ class DbusBleSensors(object):
         # Known device lists
         self._known_mac = DatedDict(ttl=DEVICE_SERVICES_TIMEOUT)
         self._ignored_mac = DatedDict(ttl=IGNORED_DEVICES_TIMEOUT)
+        self._last_adv_seen: dict[str, float] = {}
 
         # Load definition classes
         BleRole.load_classes(os.path.abspath(__file__))
@@ -140,7 +143,10 @@ class DbusBleSensors(object):
         plog = f"{dev_mac} - {device.name}:"
         logging.debug(f"{plog} received advertisement {advertisement_data!r}")
         if advertisement_data.manufacturer_data is None or len(advertisement_data.manufacturer_data) < 1:
-            logging.info(f"{plog} ignoring, device without manufacturer data")
+            now = time.monotonic()
+            if now - self._last_adv_seen.get(dev_mac, 0) >= ADV_LOG_QUIET_PERIOD:
+                logging.info(f"{plog} ignoring, device without manufacturer data")
+            self._last_adv_seen[dev_mac] = now
             self._ignored_mac[dev_mac] = True
             return
 
@@ -150,7 +156,10 @@ class DbusBleSensors(object):
 
                 device_class = BleDevice.DEVICE_CLASSES.get(man_id, None)
                 if device_class is None:
-                    logging.info(f"{plog} ignoring data {man_data!r}, no device configuration class for manufacturer {man_id!r}")
+                    now = time.monotonic()
+                    if now - self._last_adv_seen.get(dev_mac, 0) >= ADV_LOG_QUIET_PERIOD:
+                        logging.info(f"{plog} ignoring data {man_data!r}, no device configuration class for manufacturer {man_id!r}")
+                    self._last_adv_seen[dev_mac] = now
                     self._ignored_mac[dev_mac] = True
                     continue
 
@@ -169,7 +178,12 @@ class DbusBleSensors(object):
             else:
                 dev_instance = self._known_mac[dev_mac]
 
-            logging.info(f"{plog} received manufacturer data: {man_data!r}")
+            now = time.monotonic()
+            if now - self._last_adv_seen.get(dev_mac, 0) >= ADV_LOG_QUIET_PERIOD:
+                logging.info(f"{plog} received manufacturer data: {man_data!r}")
+            else:
+                logging.debug(f"{plog} received manufacturer data: {man_data!r}")
+            self._last_adv_seen[dev_mac] = now
             if dev_instance.check_manufacturer_data(man_data):
                 dev_instance.handle_manufacturer_data(man_data)
             else:

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -176,34 +176,42 @@ class DbusBleSensors(object):
                 logging.info(f"{plog} ignoring manufacturer data due to data check")
 
     def _start_scanners(self):
-        """Start passive BleakScanners in a background thread.
+        """Start BLE scanners in background threads.
 
-        We run scanners in a dedicated thread with a standard asyncio event
-        loop because the main thread uses gbulb (GLib-backed asyncio) which
-        is incompatible with dbus-fast's method-call dispatch needed for
-        passive scanning via AdvertisementMonitor1.
+        Passive scanners and nondiscoverable (DuplicateData) scanners run in
+        separate threads, each with its own asyncio event loop.  This is
+        necessary because:
 
-        Each adapter gets a persistent passive scanner.  If a scanner fails
-        to start (e.g. EBUSY because another service is adjusting scan
-        parameters), that adapter retries with exponential backoff."""
+        1. The main thread uses gbulb (GLib-backed asyncio) which is
+           incompatible with dbus-fast's method-call dispatch needed for
+           passive scanning via AdvertisementMonitor1.
+
+        2. If passive scanning's AdvertisementMonitor1 callbacks fail (e.g.
+           method signature mismatch with BlueZ), the dbus-fast connection
+           can block the event loop, preventing nondiscoverable scans from
+           starting.  Separate threads with separate event loops isolate
+           the two scanning modes from each other."""
         self._scan_buffer = []
         self._scan_buffer_lock = threading.Lock()
         self._scanner_stop = threading.Event()
 
-        def _thread_main():
-            policy = asyncio.DefaultEventLoopPolicy()
-            loop = policy.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                loop.run_until_complete(asyncio.gather(
-                    self._run_scanners(),
-                    self._run_nondiscoverable_scans(),
-                ))
-            except Exception:
-                logging.exception("Scanner thread error")
+        def _make_thread(coro_factory, name):
+            def _thread_main():
+                asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                try:
+                    loop.run_until_complete(coro_factory())
+                except Exception:
+                    logging.exception(f"{name} thread error")
+            t = threading.Thread(target=_thread_main, daemon=True, name=name)
+            t.start()
+            return t
 
-        self._scanner_thread = threading.Thread(target=_thread_main, daemon=True)
-        self._scanner_thread.start()
+        self._scanner_thread = _make_thread(
+            self._run_scanners, "passive-scanner")
+        self._nd_scanner_thread = _make_thread(
+            self._run_nondiscoverable_scans, "nondiscoverable-scanner")
 
     @staticmethod
     async def _power_cycle_adapter(adapter):
@@ -383,8 +391,8 @@ class DbusBleSensors(object):
                 try:
                     nd_results = []
 
-                    def _nd_callback(device, adv_data, _buf=nd_results):
-                        _buf.append((device, adv_data))
+                    def _nd_callback(device, adv_data):
+                        nd_results.append((device, adv_data))
 
                     scanner = bleak.BleakScanner(
                         detection_callback=_nd_callback,

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_service.py
@@ -137,15 +137,22 @@ class DbusBleService(object):
             self._set_value(f"/Devices/{dev_id}_{role_name}/Name", f"{custom_name_changes['Value']} {role_name}")
         self._dbus_settings.get_item(custom_name_setting_path).eventCallback = set_name_callback
 
-        # Add enable entry
+        # Add enable entry and fire the callback with the persisted value so
+        # that roles already enabled at startup get their D-Bus service
+        # connected immediately (on_enabled_changed is only called on
+        # *changes* by _set_proxy_setting, not for the initial value).
+        enabled_setting_path = f"/Settings/Devices/{dbus_role_service.get_dbus_id()}/Enabled"
         self._set_proxy_setting(
-            f"/Settings/Devices/{dbus_role_service.get_dbus_id()}/Enabled",
+            enabled_setting_path,
             f"/Devices/{dev_id}_{role_name}/Enabled",
             0,
             0,
             1,
             dbus_role_service.on_enabled_changed
         )
+        initial = self._dbus_settings.get_value(enabled_setting_path)
+        if initial:
+            dbus_role_service.on_enabled_changed(initial)
 
     def unregister_role_service(self, dbus_role_service):
         role_name = dbus_role_service.ble_role.NAME

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 import logging
 import sys
-import os
 import dbus
+from dbus_bus import get_bus
 from dbus_settings_service import DbusSettingsService
 from vedbus import VeDbusService, VeDbusItemImport, VeDbusItemExport
 
@@ -17,7 +17,7 @@ class DbusBleService(object):
 
     def __init__(self):
         DbusBleService._INSTANCE = self
-        self._bus: dbus.Bus = dbus.SessionBus() if 'DBUS_SESSION_BUS_ADDRESS' in os.environ else dbus.SystemBus()
+        self._bus: dbus.bus.BusConnection = get_bus(self._BLE_SERVICENAME)
         self._dbus_settings = DbusSettingsService()
 
         # Dbus local service, if needed

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_bus.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_bus.py
@@ -1,0 +1,61 @@
+"""Cached D-Bus connection factory.
+
+BusConnection objects created with DBusGMainLoop as the default main loop
+are pinned in memory by C-level GLib watch/timeout references that Python's
+GC cannot reach.  Without caching, every call site that creates a new bus
+connection leaks a connection to the D-Bus daemon, eventually exhausting
+the per-UID connection limit (typically 256 for root).
+
+Usage::
+
+    from dbus_bus import get_bus
+
+    # For a VeDbusService that registers object paths — one connection per
+    # service name so that '/' registrations don't collide:
+    bus = get_bus("com.victronenergy.tank.mopeka_abc123")
+    svc = VeDbusService("com.victronenergy.tank.mopeka_abc123", bus)
+
+    # For settings access — all callers share one connection:
+    bus = get_bus("com.victronenergy.settings")
+"""
+
+import os
+import dbus
+import dbus.bus
+
+
+class SystemBus(dbus.bus.BusConnection):
+    def __new__(cls):
+        return dbus.bus.BusConnection.__new__(cls, dbus.bus.BusConnection.TYPE_SYSTEM)
+
+
+class SessionBus(dbus.bus.BusConnection):
+    def __new__(cls):
+        return dbus.bus.BusConnection.__new__(cls, dbus.bus.BusConnection.TYPE_SESSION)
+
+
+_bus_instances: dict[str, dbus.bus.BusConnection] = {}
+
+
+def get_bus(cache_key: str) -> dbus.bus.BusConnection:
+    """Return a cached bus connection for *cache_key*, creating one if needed.
+
+    Each unique *cache_key* gets its own ``BusConnection``.  This is
+    necessary because ``VeDbusService`` registers D-Bus object paths
+    (like ``'/'``) and two services on the same connection would collide.
+
+    Use a stable, well-known name as the key:
+
+    * The service name for ``VeDbusService`` instances
+      (e.g. ``"com.victronenergy.tank.mopeka_abc123"``).
+    * ``"com.victronenergy.settings"`` for all settings access — all
+      callers can share one connection since they only make outgoing
+      method calls and don't register object paths.
+    """
+    bus = _bus_instances.get(cache_key)
+    if bus is None or not bus.get_is_connected():
+        _bus_instances[cache_key] = (
+            SessionBus() if "DBUS_SESSION_BUS_ADDRESS" in os.environ
+            else SystemBus()
+        )
+    return _bus_instances[cache_key]

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
@@ -220,8 +220,8 @@ class DbusRoleService(object):
             f"/Settings/Devices/{self._dbus_id}{name}",
             name,
             props['def'],
-            props['min'],
-            props['max'],
+            props.get('min', 0),
+            props.get('max', 0),
             callback=callback
         )
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
@@ -1,6 +1,6 @@
-import os
 import logging
 import dbus
+from dbus_bus import get_bus
 from dbus_settings_service import DbusSettingsService
 from ble_role import BleRole
 from functools import partial
@@ -14,19 +14,17 @@ class DbusRoleService(object):
     """
 
     def __init__(self, ble_device, ble_role: BleRole):
-        # private=True to allow creation of multiple services in the same app
-        self._bus: dbus.Bus = dbus.SessionBus(
-            private=True) if 'DBUS_SESSION_BUS_ADDRESS' in os.environ else dbus.SystemBus(private=True)
-        self._dbus_settings = DbusSettingsService()
         self._ble_device = ble_device
         self.ble_role = ble_role
+        self._dev_id = self._ble_device.info['dev_id']
+        self._dbus_id = f"{self._dev_id}/{self.ble_role.NAME}"
+        self._service_name = f"com.victronenergy.{self.ble_role.NAME}.{self._dev_id}"
+        self._bus: dbus.bus.BusConnection = get_bus(self._service_name)
+        self._dbus_settings = DbusSettingsService()
         self._dbus_service: VeDbusService = None
-        self._service_name: str = None
         self._dbus_iface = dbus.Interface(
             self._bus.get_object('org.freedesktop.DBus', '/org/freedesktop/DBus'),
             'org.freedesktop.DBus')
-        self._dev_id = self._ble_device.info['dev_id']
-        self._dbus_id = f"{self._dev_id}/{self.ble_role.NAME}"
         self._init_dbus_service()
 
     def is_connected(self) -> bool:
@@ -68,8 +66,6 @@ class DbusRoleService(object):
         return cur_instance
 
     def _init_dbus_service(self):
-        self._service_name = f"com.victronenergy.{self.ble_role.NAME}.{self._dev_id}"
-
         logging.debug(f"{self._ble_device._plog} initializing dbus {self._service_name!r}")
         self._dbus_service = VeDbusService(self._service_name, self._bus, False)
 
@@ -220,8 +216,8 @@ class DbusRoleService(object):
             f"/Settings/Devices/{self._dbus_id}{name}",
             name,
             props['def'],
-            props['min'],
-            props['max'],
+            props.get('min', 0),
+            props.get('max', 0),
             callback=callback
         )
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_settings_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_settings_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-import os
 import dbus
 import logging
+from dbus_bus import get_bus
 from vedbus import VeDbusItemImport, VeDbusItemExport
 
 
@@ -17,13 +17,9 @@ class DbusSettingsService(object):
     _SETTINGS_SERVICENAME = 'com.victronenergy.settings'
 
     def __init__(self):
-        self._bus: dbus.Bus = None
+        self._bus: dbus.bus.BusConnection = get_bus(self._SETTINGS_SERVICENAME)
         self._paths = {}
-        if self._bus is None:
-            self._bus = dbus.SessionBus() if 'DBUS_SESSION_BUS_ADDRESS' in os.environ else dbus.SystemBus()
-        # Check settings service exists
         if self._SETTINGS_SERVICENAME not in self._bus.list_names():
-            self._bus = None
             raise Exception(f"Dbus service {self._SETTINGS_SERVICENAME!r} does not exist.")
 
     def get_item(self, path: str, def_value: object = None, min_value: int = 0, max_value: int = 0) -> VeDbusItemImport:

--- a/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
@@ -142,7 +142,7 @@ class BleDeviceSeeLevel(BleDevice):
             'product_id': 0xA142,
             'product_name': self.PRODUCT_NAME,
             'device_name': 'SeeLevel',
-            'dev_prefix': 'seelevel',
+            'dev_prefix': self.DEV_PREFIX,
             'roles': dict(self.ROLES),
             'regs': [],
         })

--- a/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/seelevel_common.py
@@ -1,0 +1,172 @@
+"""
+SeeLevel 709-BT Protocol Reference
+====================================
+
+The Garnet SeeLevel 709-BT is a BLE Broadcaster that continuously cycles
+through its connected sensors, transmitting advertisement packets.  No BLE
+connection is required -- all data is read from manufacturer-specific data
+in the advertisement PDU.
+
+Two hardware variants exist, distinguished by manufacturer ID:
+
+  BTP3 (Cypress)   MFG ID 305  (0x0131)
+  BTP7 (SeeLevel)  MFG ID 3264 (0x0CC0)
+
+
+BLE Packet Formats
+------------------
+
+BTP3 payload (14 bytes):
+    Bytes 0-2   Coach ID (24-bit, little-endian)
+    Byte  3     Sensor number (0-13)
+    Bytes 4-6   Sensor data (3 ASCII chars: "OPN", "ERR", or numeric)
+    Bytes 7-9   Volume in gallons (3 ASCII chars)
+    Bytes 10-12 Total capacity in gallons (3 ASCII chars)
+    Byte  13    Alarm state (ASCII digit '0'-'9')
+
+BTP7 payload (14 bytes):
+    Bytes 0-2   Coach ID (24-bit, little-endian)
+    Bytes 3-10  Tank levels, 1 byte each (0-100 = %, >100 = error code)
+                Order: Fresh, Wash, Toilet, Fresh2, Wash2, Toilet2, Wash3, LPG
+    Byte  11    Battery voltage * 10 (e.g. 130 = 13.0 V)
+    Bytes 12-13 Unused
+
+
+Sensor Numbers
+--------------
+
+    Number  BTP3 (0x0131)       BTP7 (0x0CC0)
+    ------  ----------------    ----------------
+      0     Fresh Water         Fresh Water
+      1     Toilet Water        Wash Water
+      2     Wash Water          Toilet Water
+      3     LPG                 Fresh Water 2
+      4     LPG 2               Wash Water 2
+      5     Galley Water        Toilet Water 2
+      6     Galley Water 2      Wash Water 3
+      7     Temperature         LPG
+      8     Temperature 2       Battery (voltage * 10)
+      9     Temperature 3       -
+     10     Temperature 4       -
+     11     Chemical            -
+     12     Chemical 2          -
+     13     Battery (voltage*10) -
+
+
+Status / Error Codes
+--------------------
+
+BTP3: the 3-char data field (bytes 4-6) may contain:
+    "OPN"   Sensor open / disconnected (no service created)
+    "ERR"   Sensor error (service shown with error status)
+    Numeric Actual sensor reading
+
+BTP7: tank byte values > 100 are error codes:
+    101  Short Circuit
+    102  Open / No response
+    103  Bitcount error
+    104  Non-stacked config with stacked data
+    105  Stacked, missing bottom sender
+    106  Stacked, missing top sender
+    108  Bad Checksum
+    110  Tank disabled
+    111  Tank init
+
+
+Unit Conversions
+----------------
+
+    Tank Level      Direct percentage (0-100)
+    Temperature     (°F - 32) * 5/9 = °C
+    Battery Voltage Value / 10 = Volts
+    Tank Capacity   Gallons * 0.00378541 = m³  (if volume desired)
+
+
+Victron D-Bus Mappings
+----------------------
+
+Product IDs:
+    Tank Sensor         0xA142  (VE_PROD_ID_TANK_SENSOR)
+    Temperature Sensor  0xA143  (VE_PROD_ID_TEMPERATURE_SENSOR)
+    Battery Monitor     0xA381  (VE_PROD_ID_BATTERY_MONITOR)
+
+Fluid Types:
+    Fresh Water  1  (FLUID_TYPE_FRESH_WATER)
+    Waste Water  2  (FLUID_TYPE_WASTE_WATER)
+    Black Water  5  (FLUID_TYPE_BLACK_WATER)
+    LPG          8  (FLUID_TYPE_LPG)
+    Chemical     0  (custom)
+
+
+References
+----------
+
+- Protocol decode: https://github.com/custom-components/ble_monitor/issues/1181
+- BTP7 btmon capture: https://github.com/TechBlueprints/victron-seelevel-python/issues/1
+- BTP7 PR discussion: https://github.com/TechBlueprints/victron-seelevel-python/pull/2
+- Original Python impl: https://github.com/TechBlueprints/victron-seelevel-python
+"""
+
+from ve_types import *
+from ble_device import BleDevice
+import logging
+
+
+class BleDeviceSeeLevel(BleDevice):
+    """
+    Shared base class for SeeLevel 709-BT protocols.
+
+    Both BTP3 (manufacturer 305) and BTP7 (manufacturer 3264) share a common
+    advertisement header, tank level processing, and error handling.  Subclasses
+    provide protocol-specific parsing in handle_manufacturer_data().
+
+    See module docstring for the full protocol reference.
+    """
+
+    CUSTOM_PARSING = True
+
+    STATUS_CODES = {
+        101: "Short Circuit",
+        102: "Open",
+        103: "Bitcount error",
+        104: "Non-stacked config with stacked data",
+        105: "Stacked, missing bottom sender",
+        106: "Stacked, missing top sender",
+        108: "Bad Checksum",
+        110: "Tank disabled",
+        111: "Tank init",
+    }
+
+    def configure(self, manufacturer_data: bytes):
+        self.info.update({
+            'product_id': 0xA142,
+            'product_name': self.PRODUCT_NAME,
+            'device_name': 'SeeLevel',
+            'dev_prefix': 'seelevel',
+            'roles': dict(self.ROLES),
+            'regs': [],
+        })
+
+    def _parse_coach_id(self, manufacturer_data: bytes) -> int:
+        """Parse 24-bit little-endian coach ID from bytes 0-2."""
+        return int.from_bytes(manufacturer_data[0:3], byteorder='little')
+
+    def _build_tank_sensor_data(self, level: int, role_service) -> dict:
+        """Build D-Bus sensor data dict from a tank level percentage (0-100)."""
+        capacity = float(role_service['Capacity'] or 0)
+        remaining = round(capacity * level / 100.0, 3) if capacity else 0.0
+
+        return {
+            'RawValue': float(level),
+            'Level': level,
+            'Remaining': remaining,
+            'Status': 0,
+        }
+
+    def _set_error_status(self, role_service, error_code=None):
+        """Set error status on a role service. Logs the error code if known."""
+        if error_code is not None:
+            status_msg = self.STATUS_CODES.get(error_code, f"Unknown ({error_code})")
+            logging.debug(f"{self._plog} error: {status_msg}")
+        role_service['Status'] = 5
+        role_service.connect()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/start-dbus-ble-sensors-py.sh
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/start-dbus-ble-sensors-py.sh
@@ -21,4 +21,17 @@ if [ "$(get_setting /Settings/Services/BleSensors)" != 1 ]; then
   exit 1
 fi
 
+# Passive scanning requires bluetoothd with experimental features enabled.
+# If bluetoothd is not running at all, start it with -E.  If it is running
+# without -E, log a note (the Python code will fall back to active scanning).
+if ! pidof bluetoothd > /dev/null 2>&1; then
+  if [ -x /usr/libexec/bluetooth/bluetoothd ]; then
+    echo "Starting bluetoothd with experimental features for passive scanning..."
+    /usr/libexec/bluetooth/bluetoothd -E &
+    sleep 2
+  fi
+elif ! cat /proc/$(pidof bluetoothd)/cmdline 2>/dev/null | tr '\0' ' ' | grep -qE '\-E|--experimental'; then
+  echo "Note: bluetoothd running without --experimental; passive scanning will fall back to active"
+fi
+
 exec python3 "$SCRIPT_DIR/dbus_ble_sensors.py"

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/conftest.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/conftest.py
@@ -1,0 +1,70 @@
+"""Shared test fixtures: stub D-Bus and GLib modules unavailable off-device."""
+import sys
+import os
+import types
+
+_src = os.path.join(os.path.dirname(__file__), '..')
+_ext = os.path.join(_src, 'ext')
+_velib = os.path.join(_ext, 'velib_python')
+for p in (_src, _ext, _velib):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# Stub modules that require system D-Bus / GLib (not available off-device).
+# Import chain: ble_device -> dbus_ble_service -> dbus_settings_service -> vedbus -> dbus
+# Import chain: ble_role_digitalinput -> gi.repository.GLib
+_stub_names = (
+    'dbus', 'dbus.bus', 'dbus.mainloop', 'dbus.mainloop.glib',
+    'dbus.service', 'dbus.exceptions',
+    'gi', 'gi.repository',
+    'vedbus', 'settingsdevice',
+    'dbus_settings_service', 'dbus_ble_service', 'dbus_role_service',
+)
+for _name in _stub_names:
+    if _name not in sys.modules:
+        sys.modules[_name] = types.ModuleType(_name)
+
+# Wire up dbus attribute hierarchy so `dbus.bus.BusConnection` resolves
+import dbus as _dbus_stub  # noqa: E402
+_dbus_stub.SystemBus = lambda **kw: None
+_dbus_stub.SessionBus = lambda **kw: None
+_dbus_stub.Interface = lambda *a, **kw: None
+_dbus_stub.String = str
+_dbus_stub.Bus = type('Bus', (), {})
+
+_dbus_bus_stub = sys.modules['dbus.bus']
+_dbus_bus_stub.BusConnection = type('BusConnection', (), {
+    'TYPE_SYSTEM': 'system',
+    'TYPE_SESSION': 'session',
+    '__new__': lambda cls, *a, **kw: object.__new__(cls),
+    'get_is_connected': lambda self: True,
+})
+_dbus_stub.bus = _dbus_bus_stub
+
+# GLib stub with enough surface for BleRoleDigitalInput (timeout_add_seconds)
+_gi_repo = sys.modules['gi.repository']
+_gi_repo.GLib = type('GLib', (), {
+    'timeout_add_seconds': staticmethod(lambda *a, **kw: None),
+    'idle_add': staticmethod(lambda *a, **kw: None),
+})()
+
+# DbusBleService fake
+import dbus_ble_service as _dbs_stub  # noqa: E402
+_fake_ble_svc = type('FakeBleService', (), {
+    'register_role_service': lambda self, *a: None,
+    'unregister_role_service': lambda self, *a: None,
+    '_get_value': lambda self, *a: 1,
+})()
+_dbs_stub.DbusBleService = type(
+    'DbusBleService', (), {'get': staticmethod(lambda: _fake_ble_svc)}
+)
+
+# DbusRoleService fake
+import dbus_role_service as _drs_stub  # noqa: E402
+_drs_stub.DbusRoleService = type('DbusRoleService', (), {})
+
+# vedbus fakes
+import vedbus as _vedbus_stub  # noqa: E402
+_vedbus_stub.VeDbusService = type('VeDbusService', (), {})
+_vedbus_stub.VeDbusItemImport = type('VeDbusItemImport', (), {})
+_vedbus_stub.VeDbusItemExport = type('VeDbusItemExport', (), {})

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_mopeka.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_mopeka.py
@@ -39,18 +39,8 @@ class BleDeviceSafieryTests(BleDeviceBaseTests):
                     'HardwareID': 3,
                     'TankLevelExtension': 0,
                     'BatteryVoltage': 3.125,
+                    'Temperature': 20.0,
                     'RawValue': 5000,
                 },
-                "temperature": {
-                    'HardwareID': 3,
-                    'BatteryVoltage': 3.125,
-                    'Temperature': 20.0,
-                },
-                "movement": {
-                    'HardwareID': 3,
-                    'BatteryVoltage': 3.125,
-                    'AccelX': -0.01171875,
-                    'AccelY': 0.0078125,
-                }
             }
         )

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -15,50 +15,6 @@ BTP7 capture — btmon, MAC D8:3B:DA:F8:24:06 (@atillack, GitHub issue
     battery 13.0 V.  Confirmed by @atillack: "hex value is 82 which is 130
     decimal - divide by 10.0 and you get the actual voltage of 13.0 V".
 """
-import sys
-import os
-import types
-
-sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext'))
-sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext', 'velib_python'))
-
-# Stub modules that require system D-Bus (not available off-device).
-# Import chain: seelevel_common -> ble_device -> dbus_ble_service ->
-# dbus_settings_service -> vedbus -> dbus.
-_stub_names = (
-    'dbus', 'dbus.mainloop', 'dbus.mainloop.glib',
-    'dbus.service', 'dbus.exceptions',
-    'vedbus', 'settingsdevice',
-    'dbus_settings_service', 'dbus_ble_service', 'dbus_role_service',
-)
-for _name in _stub_names:
-    if _name not in sys.modules:
-        sys.modules[_name] = types.ModuleType(_name)
-
-import dbus as _dbus_stub
-_dbus_stub.SystemBus = lambda **kw: None
-_dbus_stub.SessionBus = lambda **kw: None
-_dbus_stub.Interface = lambda *a, **kw: None
-_dbus_stub.String = str
-_dbus_stub.Bus = type('Bus', (), {})
-
-import dbus_ble_service as _dbs_stub
-_fake_ble_svc = type('FakeBleService', (), {
-    'register_role_service': lambda self, *a: None,
-    'unregister_role_service': lambda self, *a: None,
-    '_get_value': lambda self, *a: 1,
-})()
-_dbs_stub.DbusBleService = type('DbusBleService', (), {'get': staticmethod(lambda: _fake_ble_svc)})
-
-import dbus_role_service as _drs_stub
-_drs_stub.DbusRoleService = type('DbusRoleService', (), {})
-
-import vedbus as _vedbus_stub
-_vedbus_stub.VeDbusService = type('VeDbusService', (), {})
-_vedbus_stub.VeDbusItemImport = type('VeDbusItemImport', (), {})
-_vedbus_stub.VeDbusItemExport = type('VeDbusItemExport', (), {})
-
 import unittest
 from ble_device_seelevel_btp3 import BleDeviceSeeLevelBTP3
 from ble_device_seelevel_btp7 import BleDeviceSeeLevelBTP7

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -174,8 +174,8 @@ def _make_device(cls, mac='00a0508d9569'):
     dev._plog = 'test:'
     dev.info = {
         'dev_mac': mac,
-        'dev_id': f'seelevel_{mac}',
-        'dev_prefix': 'seelevel',
+        'dev_id': f'{cls.DEV_PREFIX}_{mac}',
+        'dev_prefix': cls.DEV_PREFIX,
         'product_id': 0xA142,
         'product_name': cls.PRODUCT_NAME,
         'device_name': 'SeeLevel',

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -1,0 +1,626 @@
+"""
+Tests for SeeLevel BTP3 and BTP7 BLE advertisement parsing.
+
+All test payloads below are real captures unless explicitly marked synthetic.
+
+BTP3 captures — Cerbo GX, MAC 00:A0:50:8D:95:69 (2025 Airstream Flying Cloud)
+    Coach ID 0x699589 (bytes 8d 95 69, little-endian)
+    5 active sensors cycling: 0 (Fresh), 1 (Toilet), 2 (Wash), 3 (LPG), 13 (Battery)
+    Sensors 4-12 not connected to hardware — never appear in advertisements.
+
+BTP7 capture — btmon, MAC D8:3B:DA:F8:24:06 (@atillack, GitHub issue
+    TechBlueprints/victron-seelevel-python#1)
+    Coach ID 0x000491 (bytes 91 04 00, little-endian)
+    3 active tanks (Fresh=25%, Wash=0%, Toilet=0%), 5 disabled (code 110),
+    battery 13.0 V.  Confirmed by @atillack: "hex value is 82 which is 130
+    decimal - divide by 10.0 and you get the actual voltage of 13.0 V".
+"""
+import sys
+import os
+import types
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext', 'velib_python'))
+
+# Stub modules that require system D-Bus (not available off-device).
+# Import chain: seelevel_common -> ble_device -> dbus_ble_service ->
+# dbus_settings_service -> vedbus -> dbus.
+_stub_names = (
+    'dbus', 'dbus.mainloop', 'dbus.mainloop.glib',
+    'dbus.service', 'dbus.exceptions',
+    'vedbus', 'settingsdevice',
+    'dbus_settings_service', 'dbus_ble_service', 'dbus_role_service',
+)
+for _name in _stub_names:
+    if _name not in sys.modules:
+        sys.modules[_name] = types.ModuleType(_name)
+
+import dbus as _dbus_stub
+_dbus_stub.SystemBus = lambda **kw: None
+_dbus_stub.SessionBus = lambda **kw: None
+_dbus_stub.Interface = lambda *a, **kw: None
+_dbus_stub.String = str
+_dbus_stub.Bus = type('Bus', (), {})
+
+import dbus_ble_service as _dbs_stub
+_fake_ble_svc = type('FakeBleService', (), {
+    'register_role_service': lambda self, *a: None,
+    'unregister_role_service': lambda self, *a: None,
+    '_get_value': lambda self, *a: 1,
+})()
+_dbs_stub.DbusBleService = type('DbusBleService', (), {'get': staticmethod(lambda: _fake_ble_svc)})
+
+import dbus_role_service as _drs_stub
+_drs_stub.DbusRoleService = type('DbusRoleService', (), {})
+
+import vedbus as _vedbus_stub
+_vedbus_stub.VeDbusService = type('VeDbusService', (), {})
+_vedbus_stub.VeDbusItemImport = type('VeDbusItemImport', (), {})
+_vedbus_stub.VeDbusItemExport = type('VeDbusItemExport', (), {})
+
+import unittest
+from ble_device_seelevel_btp3 import BleDeviceSeeLevelBTP3
+from ble_device_seelevel_btp7 import BleDeviceSeeLevelBTP7
+
+
+# ===================================================================
+# Raw captures
+# ===================================================================
+
+# -- BTP3: Cerbo GX, MAC 00:A0:50:8D:95:69 -------------------------
+#
+# Coach ID = 8d 95 69  (0x699589 LE)
+# Byte 3   = sensor number
+# Bytes 4-6 = 3 ASCII chars (value)
+# Bytes 7-9 = volume (gallons), 10-12 = capacity (gallons)
+# Byte 13  = alarm ('0'-'9')
+
+BTP3_FRESH_WATER_0PCT  = b'\x8d\x95i\x00  00000000'   # sensor 0, val "  0"
+BTP3_TOILET_WATER_0PCT = b'\x8d\x95i\x01  00000000'   # sensor 1, val "  0"
+BTP3_WASH_WATER_0PCT   = b'\x8d\x95i\x02  00000000'   # sensor 2, val "  0"
+BTP3_LPG_OPEN          = b'\x8d\x95i\x03OPN0000000'   # sensor 3, val "OPN"
+BTP3_BATTERY_13V7      = b'\x8d\x95i\r1370000000'     # sensor 13, val "137"
+
+# -- BTP7: btmon, MAC D8:3B:DA:F8:24:06 ----------------------------
+#
+# Raw hex from btmon: 9104001900006e6e6e6e6e820000
+#
+#   91 04 00   coach ID (0x000491 LE)
+#   19         Fresh  = 25%
+#   00         Wash   =  0%
+#   00         Toilet =  0%
+#   6e         Fresh2 = 110 (tank disabled)
+#   6e         Wash2  = 110
+#   6e         Toilet2= 110
+#   6e         Wash3  = 110
+#   6e         LPG    = 110
+#   82         Battery= 130 -> 13.0 V
+#   00 00      unused
+
+BTP7_CAPTURE = bytes.fromhex('9104001900006e6e6e6e6e820000')
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+class MockRoleService(dict):
+    """Dict-like stand-in for DbusRoleService (no D-Bus required)."""
+
+    def __init__(self, defaults=None):
+        super().__init__(defaults or {})
+        self.connected = False
+
+    def connect(self):
+        self.connected = True
+
+    def disconnect(self):
+        self.connected = False
+
+    def get_dev_id(self):
+        return 'test_dev'
+
+    def get_dbus_id(self):
+        return 'test_dev/tank'
+
+
+def _make_device(cls, mac='00a0508d9569'):
+    """Instantiate a SeeLevel device without D-Bus, wiring up minimal state."""
+    dev = cls.__new__(cls)
+    dev._role_services = {}
+    dev._plog = 'test:'
+    dev.info = {
+        'dev_mac': mac,
+        'dev_id': f'seelevel_{mac}',
+        'dev_prefix': 'seelevel',
+        'product_id': 0xA142,
+        'product_name': cls.PRODUCT_NAME,
+        'device_name': 'SeeLevel',
+        'hardware_version': '1.0.0',
+        'firmware_version': '1.0.0',
+        'roles': dict(cls.ROLES),
+        'regs': [],
+        'settings': [],
+        'alarms': [],
+    }
+    return dev
+
+
+def _mock_create_service(dev, role_type, index, device_name=None, defaults=None):
+    """Register a MockRoleService in the device's _role_services dict."""
+    key = f'{role_type}_{index:02d}'
+    svc = MockRoleService(defaults or {})
+    svc._device_name = device_name
+    dev._role_services[key] = svc
+    return svc
+
+
+# ===================================================================
+# BTP3 — check_manufacturer_data
+# ===================================================================
+
+class TestBTP3CheckManufacturerData(unittest.TestCase):
+
+    def setUp(self):
+        self.dev = _make_device(BleDeviceSeeLevelBTP3)
+
+    def test_accepts_sensor_0(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_FRESH_WATER_0PCT))
+
+    def test_accepts_sensor_1(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_TOILET_WATER_0PCT))
+
+    def test_accepts_sensor_2(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_WASH_WATER_0PCT))
+
+    def test_accepts_sensor_3_opn(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_LPG_OPEN))
+
+    def test_accepts_sensor_13_battery(self):
+        self.assertTrue(self.dev.check_manufacturer_data(BTP3_BATTERY_13V7))
+
+    def test_rejects_too_short(self):
+        self.assertFalse(self.dev.check_manufacturer_data(
+            BTP3_FRESH_WATER_0PCT[:6]))
+
+    def test_rejects_unknown_sensor_14(self):
+        # synthetic: sensor number 14 does not exist
+        self.assertFalse(self.dev.check_manufacturer_data(
+            b'\x8d\x95i\x0e0000000000'))
+
+
+# ===================================================================
+# BTP3 — handle_manufacturer_data
+# ===================================================================
+
+class TestBTP3HandleManufacturerData(unittest.TestCase):
+
+    def setUp(self):
+        self.dev = _make_device(BleDeviceSeeLevelBTP3)
+
+    def _enable_sensor(self, role_type, index, defaults=None):
+        return _mock_create_service(self.dev, role_type, index, defaults=defaults)
+
+    def _patch_enabled(self):
+        self.dev._is_indexed_role_enabled = lambda *a: True
+
+    # -- Real BTP3 captures: tanks at 0% --------------------------------
+
+    def test_fresh_water_0pct(self):
+        """Real capture: sensor 0 (Fresh Water), value '  0' -> 0%."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertEqual(svc['Level'], 0)
+        self.assertEqual(svc['RawValue'], 0.0)
+        self.assertEqual(svc['Remaining'], 0.0)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    def test_toilet_water_0pct(self):
+        """Real capture: sensor 1 (Toilet Water), value '  0' -> 0%."""
+        svc = self._enable_sensor('tank', 1, {
+            'FluidType': 5, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_TOILET_WATER_0PCT)
+
+        self.assertEqual(svc['Level'], 0)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    def test_wash_water_0pct(self):
+        """Real capture: sensor 2 (Wash Water), value '  0' -> 0%."""
+        svc = self._enable_sensor('tank', 2, {
+            'FluidType': 2, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_WASH_WATER_0PCT)
+
+        self.assertEqual(svc['Level'], 0)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    # -- Real BTP3 capture: OPN (disconnected) ---------------------------
+
+    def test_lpg_opn_skipped(self):
+        """Real capture: sensor 3 (LPG), value 'OPN' -> no update."""
+        svc = self._enable_sensor('tank', 3, {
+            'FluidType': 8, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_LPG_OPEN)
+
+        self.assertNotIn('Level', svc)
+        self.assertFalse(svc.connected)
+
+    # -- Real BTP3 capture: battery voltage ------------------------------
+
+    def test_battery_13v7(self):
+        """Real capture: sensor 13, value '137' -> 13.7 V."""
+        svc = self._enable_sensor('battery', 13, {'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_BATTERY_13V7)
+
+        self.assertAlmostEqual(svc['/Dc/0/Voltage'], 13.7, places=1)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    # -- Real capture: alarm byte ----------------------------------------
+
+    def test_alarm_byte_zero_from_real_capture(self):
+        """Real capture: all captured payloads have alarm byte '0' (0x30)."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertEqual(svc['/Alarms/Low/State'], 0)
+
+    # -- Synthetic: cases not covered by real hardware -------------------
+
+    def test_err_sets_error_status(self):
+        """Synthetic: sensor 0, value 'ERR' -> Status 5."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00ERR0000000')
+
+        self.assertEqual(svc['Status'], 5)
+        self.assertTrue(svc.connected)
+
+    def test_tank_50pct_with_capacity(self):
+        """Synthetic: sensor 0 at 50%, capacity 0.2 m3 -> remaining 0.1."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.2, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 500000000')
+
+        self.assertEqual(svc['Level'], 50)
+        self.assertAlmostEqual(svc['Remaining'], 0.1, places=3)
+
+    def test_tank_clamps_to_100(self):
+        """Synthetic: value > 100 is clamped to 100%."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x001200000000')
+
+        self.assertEqual(svc['Level'], 100)
+
+    def test_alarm_nonzero(self):
+        """Synthetic: alarm byte '3' -> low alarm active."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 100000003')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 1)
+
+    def test_temperature_72f(self):
+        """Synthetic: sensor 7 (Temp), value '072' (72 degF) -> 22.2 degC."""
+        svc = self._enable_sensor('temperature', 7, {'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x070720000000')
+
+        self.assertAlmostEqual(svc['Temperature'], 22.2, places=1)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    def test_temperature_32f_freezing(self):
+        """Synthetic: sensor 7, value '032' (32 degF) -> 0.0 degC."""
+        svc = self._enable_sensor('temperature', 7, {'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x070320000000')
+
+        self.assertAlmostEqual(svc['Temperature'], 0.0, places=1)
+
+    def test_battery_low_voltage(self):
+        """Synthetic: sensor 13, value '108' -> 10.8 V."""
+        svc = self._enable_sensor('battery', 13, {'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\r1080000000')
+
+        self.assertAlmostEqual(svc['/Dc/0/Voltage'], 10.8, places=1)
+
+    def test_unparseable_value_ignored(self):
+        """Synthetic: non-numeric, non-OPN/ERR data -> no crash."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00XYZ0000000')
+
+        self.assertNotIn('Level', svc)
+
+    # -- Lazy service creation (uses real capture to trigger) ------------
+
+    def test_lazy_creates_tank_service(self):
+        """Real capture triggers lazy creation of tank service."""
+        self._patch_enabled()
+        created = {}
+
+        def mock_create(role_type, index, device_name=None):
+            svc = _mock_create_service(self.dev, role_type, index,
+                                       device_name=device_name,
+                                       defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
+            created[f'{role_type}_{index:02d}'] = svc
+            return svc
+
+        self.dev._create_indexed_role_service = mock_create
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertIn('tank_00', created)
+        self.assertEqual(created['tank_00']._device_name, 'SeeLevel Fresh Water')
+
+    def test_lazy_sets_fluid_type(self):
+        """Lazy creation sets FluidType from SENSORS table."""
+        self._patch_enabled()
+
+        def mock_create(role_type, index, device_name=None):
+            return _mock_create_service(self.dev, role_type, index,
+                                       defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
+
+        self.dev._create_indexed_role_service = mock_create
+        self.dev.handle_manufacturer_data(BTP3_TOILET_WATER_0PCT)
+
+        svc = self.dev._role_services['tank_01']
+        self.assertEqual(svc['FluidType'], 5)  # Black water
+
+    def test_lazy_zeroes_default_capacity(self):
+        """Lazy creation resets upstream default capacity 0.2 -> 0.0."""
+        self._patch_enabled()
+
+        def mock_create(role_type, index, device_name=None):
+            return _mock_create_service(self.dev, role_type, index,
+                                       defaults={'FluidType': 0, 'Capacity': 0.2, 'Status': 0})
+
+        self.dev._create_indexed_role_service = mock_create
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        svc = self.dev._role_services['tank_00']
+        self.assertEqual(svc['Capacity'], 0.0)
+
+    # -- Disabled sensor -------------------------------------------------
+
+    def test_disabled_sensor_not_updated(self):
+        """Real capture, but sensor disabled -> no D-Bus update."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+        self.dev._is_indexed_role_enabled = lambda *a: False
+
+        self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
+
+        self.assertNotIn('Level', svc)
+        self.assertFalse(svc.connected)
+
+
+# ===================================================================
+# BTP7 — check_manufacturer_data
+# ===================================================================
+
+class TestBTP7CheckManufacturerData(unittest.TestCase):
+
+    def setUp(self):
+        self.dev = _make_device(BleDeviceSeeLevelBTP7, 'd83bdaf82406')
+
+    def test_accepts_real_capture(self):
+        """Real btmon capture: 14 bytes."""
+        self.assertTrue(self.dev.check_manufacturer_data(BTP7_CAPTURE))
+
+    def test_accepts_minimum_12_bytes(self):
+        """12 bytes is the minimum for tank + battery."""
+        self.assertTrue(self.dev.check_manufacturer_data(BTP7_CAPTURE[:12]))
+
+    def test_rejects_11_bytes(self):
+        """11 bytes is too short (missing battery byte)."""
+        self.assertFalse(self.dev.check_manufacturer_data(BTP7_CAPTURE[:11]))
+
+
+# ===================================================================
+# BTP7 — handle_manufacturer_data (real capture)
+# ===================================================================
+
+class TestBTP7HandleManufacturerData(unittest.TestCase):
+    """
+    All tests in this class use the real btmon capture from @atillack
+    (GitHub TechBlueprints/victron-seelevel-python#1) unless marked synthetic.
+    """
+
+    def setUp(self):
+        self.dev = _make_device(BleDeviceSeeLevelBTP7, 'd83bdaf82406')
+        self.dev._is_indexed_role_enabled = lambda *a: True
+
+        for slot in range(8):
+            name, fluid = BleDeviceSeeLevelBTP7.TANK_SLOTS[slot]
+            _mock_create_service(self.dev, 'tank', slot, device_name=f'SeeLevel {name}',
+                                 defaults={'FluidType': fluid, 'Capacity': 0.0, 'Status': 0})
+        _mock_create_service(self.dev, 'battery', 8, device_name='SeeLevel Voltage',
+                             defaults={'Status': 0})
+
+    # -- Active tanks from real capture ----------------------------------
+
+    def test_fresh_water_25pct(self):
+        """Byte 3 = 0x19 = 25 -> Fresh Water at 25%."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['tank_00']
+        self.assertEqual(svc['Level'], 25)
+        self.assertEqual(svc['RawValue'], 25.0)
+        self.assertEqual(svc['Remaining'], 0.0)
+        self.assertTrue(svc.connected)
+
+    def test_wash_water_0pct(self):
+        """Byte 4 = 0x00 -> Wash Water at 0%."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['tank_01']
+        self.assertEqual(svc['Level'], 0)
+        self.assertTrue(svc.connected)
+
+    def test_toilet_water_0pct(self):
+        """Byte 5 = 0x00 -> Toilet Water at 0%."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['tank_02']
+        self.assertEqual(svc['Level'], 0)
+        self.assertTrue(svc.connected)
+
+    # -- Disabled tanks from real capture (code 110) ---------------------
+
+    def test_fresh2_disabled(self):
+        """Byte 6 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_03']['Status'], 5)
+
+    def test_wash2_disabled(self):
+        """Byte 7 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_04']['Status'], 5)
+
+    def test_toilet2_disabled(self):
+        """Byte 8 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_05']['Status'], 5)
+
+    def test_wash3_disabled(self):
+        """Byte 9 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_06']['Status'], 5)
+
+    def test_lpg_disabled(self):
+        """Byte 10 = 0x6e = 110 (tank disabled) -> error status."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+        self.assertEqual(self.dev._role_services['tank_07']['Status'], 5)
+
+    # -- Battery voltage from real capture -------------------------------
+
+    def test_battery_13v0(self):
+        """Byte 11 = 0x82 = 130 -> 13.0 V (confirmed by @atillack)."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['battery_08']
+        self.assertAlmostEqual(svc['/Dc/0/Voltage'], 13.0, places=1)
+        self.assertEqual(svc['Status'], 0)
+        self.assertTrue(svc.connected)
+
+    # -- Synthetic: edge cases -------------------------------------------
+
+    def test_tank_with_capacity(self):
+        """Synthetic: slot 0 at 40%, capacity 0.3 m3 -> remaining 0.12."""
+        self.dev._role_services['tank_00']['Capacity'] = 0.3
+
+        payload = bytearray(BTP7_CAPTURE)
+        payload[3] = 40
+        self.dev.handle_manufacturer_data(bytes(payload))
+
+        svc = self.dev._role_services['tank_00']
+        self.assertEqual(svc['Level'], 40)
+        self.assertAlmostEqual(svc['Remaining'], 0.12, places=3)
+
+    def test_all_tanks_100pct(self):
+        """Synthetic: all 8 tanks at exactly 100%."""
+        payload = bytearray(14)
+        payload[0:3] = b'\x91\x04\x00'
+        for i in range(8):
+            payload[3 + i] = 100
+        payload[11] = 130
+
+        self.dev.handle_manufacturer_data(bytes(payload))
+
+        for slot in range(8):
+            svc = self.dev._role_services[f'tank_{slot:02d}']
+            self.assertEqual(svc['Level'], 100,
+                             f'slot {slot} should be 100%')
+
+    def test_battery_low_voltage(self):
+        """Synthetic: byte 11 = 110 -> 11.0 V."""
+        payload = bytearray(BTP7_CAPTURE)
+        payload[11] = 110
+        self.dev.handle_manufacturer_data(bytes(payload))
+
+        svc = self.dev._role_services['battery_08']
+        self.assertAlmostEqual(svc['/Dc/0/Voltage'], 11.0, places=1)
+
+    def test_battery_disabled_not_updated(self):
+        """Battery slot disabled -> no voltage update."""
+        self.dev._is_indexed_role_enabled = lambda rt, idx: rt == 'tank'
+
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        svc = self.dev._role_services['battery_08']
+        self.assertNotIn('/Dc/0/Voltage', svc)
+        self.assertFalse(svc.connected)
+
+    def test_short_payload_battery_safe(self):
+        """11-byte payload: tanks update, battery skipped (< 12 bytes)."""
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE[:11])
+
+        svc = self.dev._role_services['battery_08']
+        self.assertNotIn('/Dc/0/Voltage', svc)
+
+
+# ===================================================================
+# Sensor mapping consistency
+# ===================================================================
+
+class TestSensorMappings(unittest.TestCase):
+
+    def test_btp3_sensor_count(self):
+        self.assertEqual(len(BleDeviceSeeLevelBTP3.SENSORS), 14)
+
+    def test_btp3_all_sensors_have_role(self):
+        for num, (name, role_type, _) in BleDeviceSeeLevelBTP3.SENSORS.items():
+            self.assertIn(role_type, ('tank', 'temperature', 'battery'),
+                          f'sensor {num} ({name}) has unexpected role {role_type!r}')
+
+    def test_btp3_battery_is_sensor_13(self):
+        name, role_type, _ = BleDeviceSeeLevelBTP3.SENSORS[13]
+        self.assertEqual(role_type, 'battery')
+
+    def test_btp7_tank_slot_count(self):
+        self.assertEqual(len(BleDeviceSeeLevelBTP7.TANK_SLOTS), 8)
+
+    def test_btp7_roles_include_battery(self):
+        self.assertIn('battery', BleDeviceSeeLevelBTP7.ROLES)
+
+    def test_btp3_roles_include_all_three(self):
+        for role in ('tank', 'temperature', 'battery'):
+            self.assertIn(role, BleDeviceSeeLevelBTP3.ROLES)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -106,7 +106,38 @@ BTP7_CAPTURE = bytes.fromhex('9104001900006e6e6e6e6e820000')
 # ===================================================================
 
 class _NullRole:
-    """Stub role whose update_data is a no-op."""
+    """Stub role whose update_data is a no-op and has no alarms."""
+    info = {'alarms': []}
+
+    def update_data(self, role_service, sensor_data):
+        pass
+
+
+def _get_alarm_low_state(role_service) -> int:
+    if role_service['/Alarms/Low/Enable']:
+        alarm_state = bool(role_service['/Alarms/Low/State'])
+        threshold = role_service[f"/Alarms/Low/{'Restore' if alarm_state else 'Active'}"]
+        return int(float(role_service['Level']) < threshold)
+    return 0
+
+
+def _get_alarm_high_state(role_service) -> int:
+    if role_service['/Alarms/High/Enable']:
+        alarm_state = bool(role_service['/Alarms/High/State'])
+        threshold = role_service[f"/Alarms/High/{'Restore' if alarm_state else 'Active'}"]
+        return int(float(role_service['Level']) > threshold)
+    return 0
+
+
+class _MockTankRole:
+    """Stub tank role with framework alarm definitions."""
+    info = {
+        'alarms': [
+            {'name': '/Alarms/High/State', 'update': _get_alarm_high_state},
+            {'name': '/Alarms/Low/State', 'update': _get_alarm_low_state},
+        ]
+    }
+
     def update_data(self, role_service, sensor_data):
         pass
 
@@ -124,6 +155,10 @@ class MockRoleService(dict):
 
     def disconnect(self):
         self.connected = False
+
+    def update_alarm(self, alarm: dict):
+        alarm_state = alarm['update'](self)
+        self[alarm['name']] = alarm_state
 
     def get_dev_id(self):
         return 'test_dev'
@@ -278,17 +313,105 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
         self.assertEqual(svc['Status'], 0)
         self.assertTrue(svc.connected)
 
-    # -- Real capture: alarm byte ----------------------------------------
+    # -- Framework alarm evaluation ---------------------------------------
 
-    def test_alarm_byte_zero_from_real_capture(self):
-        """Real capture: all captured payloads have alarm byte '0' (0x30)."""
+    def test_framework_alarm_low_disabled(self):
+        """Framework alarms disabled -> /Alarms/Low/State stays 0."""
         svc = self._enable_sensor('tank', 0, {
-            'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 0, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
         self._patch_enabled()
 
         self.dev.handle_manufacturer_data(BTP3_FRESH_WATER_0PCT)
 
         self.assertEqual(svc['/Alarms/Low/State'], 0)
+
+    def test_framework_alarm_low_triggered(self):
+        """Tank at 5% with low alarm enabled (Active=10) -> alarm fires."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 1, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00  50000000')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 1)
+
+    def test_framework_alarm_low_not_triggered(self):
+        """Tank at 50% with low alarm enabled (Active=10) -> no alarm."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 1, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 500000000')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 0)
+
+    def test_framework_alarm_high_triggered(self):
+        """Tank at 95% with high alarm enabled (Active=90) -> alarm fires."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 0, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 1, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 950000000')
+
+        self.assertEqual(svc['/Alarms/High/State'], 1)
+
+    def test_framework_alarm_hysteresis(self):
+        """Alarm active: level must rise above Restore (15) to clear."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 1, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 1,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 120000000')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 1,
+                         "12% is below Restore(15), alarm should stay active")
+
+    def test_hardware_alarm_byte_not_used(self):
+        """Hardware alarm byte '3' no longer sets /Alarms/Low/State directly."""
+        svc = self._enable_sensor('tank', 0, {
+            'FluidType': 1, 'Capacity': 0.0, 'Status': 0,
+            '/Alarms/Low/Enable': 0, '/Alarms/Low/Active': 10,
+            '/Alarms/Low/Restore': 15, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+        self._patch_enabled()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 100000003')
+
+        self.assertEqual(svc['/Alarms/Low/State'], 0,
+                         "alarms disabled, hw byte should not override")
 
     # -- Synthetic: cases not covered by real hardware -------------------
 
@@ -324,15 +447,15 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
 
         self.assertEqual(svc['Level'], 100)
 
-    def test_alarm_nonzero(self):
-        """Synthetic: alarm byte '3' -> low alarm active."""
+    def test_alarm_null_role_no_crash(self):
+        """Tank with _NullRole (no alarms defined) -> no crash."""
         svc = self._enable_sensor('tank', 0, {
             'FluidType': 1, 'Capacity': 0.0, 'Status': 0})
         self._patch_enabled()
 
-        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 100000003')
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x00 500000000')
 
-        self.assertEqual(svc['/Alarms/Low/State'], 1)
+        self.assertEqual(svc['Level'], 50)
 
     def test_temperature_72f(self):
         """Synthetic: sensor 7 (Temp), value '072' (72 degF) -> 22.2 degC."""
@@ -560,6 +683,38 @@ class TestBTP7HandleManufacturerData(unittest.TestCase):
         self.assertAlmostEqual(svc['/Dc/0/Voltage'], 13.0, places=1)
         self.assertEqual(svc['Status'], 0)
         self.assertTrue(svc.connected)
+
+    # -- Framework alarm evaluation (BTP7) --------------------------------
+
+    def test_framework_alarm_low_btp7(self):
+        """BTP7: Fresh at 25% with low alarm enabled (Active=30) -> alarm fires."""
+        svc = self.dev._role_services['tank_00']
+        svc.update({
+            '/Alarms/Low/Enable': 1, '/Alarms/Low/Active': 30,
+            '/Alarms/Low/Restore': 35, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        self.assertEqual(svc['/Alarms/Low/State'], 1)
+
+    def test_framework_alarm_disabled_btp7(self):
+        """BTP7: Fresh at 25% with alarms disabled -> no alarm."""
+        svc = self.dev._role_services['tank_00']
+        svc.update({
+            '/Alarms/Low/Enable': 0, '/Alarms/Low/Active': 30,
+            '/Alarms/Low/Restore': 35, '/Alarms/Low/State': 0,
+            '/Alarms/High/Enable': 0, '/Alarms/High/Active': 90,
+            '/Alarms/High/Restore': 80, '/Alarms/High/State': 0,
+        })
+        svc.ble_role = _MockTankRole()
+
+        self.dev.handle_manufacturer_data(BTP7_CAPTURE)
+
+        self.assertEqual(svc['/Alarms/Low/State'], 0)
 
     # -- Synthetic: edge cases -------------------------------------------
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_ble_device_seelevel.py
@@ -105,12 +105,19 @@ BTP7_CAPTURE = bytes.fromhex('9104001900006e6e6e6e6e820000')
 # Helpers
 # ===================================================================
 
+class _NullRole:
+    """Stub role whose update_data is a no-op."""
+    def update_data(self, role_service, sensor_data):
+        pass
+
+
 class MockRoleService(dict):
     """Dict-like stand-in for DbusRoleService (no D-Bus required)."""
 
     def __init__(self, defaults=None):
         super().__init__(defaults or {})
         self.connected = False
+        self.ble_role = _NullRole()
 
     def connect(self):
         self.connected = True
@@ -346,6 +353,23 @@ class TestBTP3HandleManufacturerData(unittest.TestCase):
         self.dev.handle_manufacturer_data(b'\x8d\x95i\x070320000000')
 
         self.assertAlmostEqual(svc['Temperature'], 0.0, places=1)
+
+    def test_temperature_offset_applied(self):
+        """Synthetic: temperature offset +2.5 is applied via role update_data."""
+        svc = self._enable_sensor('temperature', 7, {'Status': 0, 'Offset': 2.5})
+        self._patch_enabled()
+
+        class OffsetRole:
+            def update_data(self, role_service, sensor_data):
+                offset = role_service.get('Offset', 0)
+                if offset and 'Temperature' in sensor_data:
+                    sensor_data['Temperature'] = sensor_data['Temperature'] + offset
+
+        svc.ble_role = OffsetRole()
+
+        self.dev.handle_manufacturer_data(b'\x8d\x95i\x070720000000')
+
+        self.assertAlmostEqual(svc['Temperature'], 24.7, places=1)
 
     def test_battery_low_voltage(self):
         """Synthetic: sensor 13, value '108' -> 10.8 V."""

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_dbus_bus.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_dbus_bus.py
@@ -1,19 +1,9 @@
 """Tests for dbus_bus.get_bus() connection caching."""
-import sys
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-# Mock dbus before importing dbus_bus
-_mock_dbus = MagicMock()
-_mock_dbus_bus = MagicMock()
-sys.modules.setdefault('dbus', _mock_dbus)
-sys.modules.setdefault('dbus.bus', _mock_dbus_bus)
-
-# Add source directory to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
-
-import dbus_bus  # noqa: E402
-import pytest  # noqa: E402
+import dbus_bus
+import pytest
 
 
 @pytest.fixture(autouse=True)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_dbus_bus.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_dbus_bus.py
@@ -1,0 +1,134 @@
+"""Tests for dbus_bus.get_bus() connection caching."""
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+# Mock dbus before importing dbus_bus
+_mock_dbus = MagicMock()
+_mock_dbus_bus = MagicMock()
+sys.modules.setdefault('dbus', _mock_dbus)
+sys.modules.setdefault('dbus.bus', _mock_dbus_bus)
+
+# Add source directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import dbus_bus  # noqa: E402
+import pytest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear the connection cache between tests."""
+    dbus_bus._bus_instances.clear()
+    yield
+    dbus_bus._bus_instances.clear()
+
+
+class FakeBus:
+    """Minimal stand-in for dbus.bus.BusConnection."""
+
+    def __init__(self, connected=True):
+        self._connected = connected
+
+    def get_is_connected(self):
+        return self._connected
+
+
+class TestGetBus:
+    def test_returns_same_connection_for_same_key(self):
+        bus = FakeBus()
+        with patch.object(dbus_bus, 'SystemBus', return_value=bus), \
+             patch.dict(os.environ, {}, clear=True):
+            first = dbus_bus.get_bus("com.victronenergy.tank.test1")
+            second = dbus_bus.get_bus("com.victronenergy.tank.test1")
+            assert first is second
+
+    def test_returns_different_connections_for_different_keys(self):
+        buses = [FakeBus(), FakeBus()]
+        call_count = 0
+
+        def make_bus():
+            nonlocal call_count
+            b = buses[call_count]
+            call_count += 1
+            return b
+
+        with patch.object(dbus_bus, 'SystemBus', side_effect=make_bus), \
+             patch.dict(os.environ, {}, clear=True):
+            first = dbus_bus.get_bus("com.victronenergy.tank.aaa")
+            second = dbus_bus.get_bus("com.victronenergy.tank.bbb")
+            assert first is not second
+
+    def test_reconnects_when_disconnected(self):
+        old_bus = FakeBus(connected=False)
+        new_bus = FakeBus(connected=True)
+
+        dbus_bus._bus_instances["com.victronenergy.settings"] = old_bus
+
+        with patch.object(dbus_bus, 'SystemBus', return_value=new_bus), \
+             patch.dict(os.environ, {}, clear=True):
+            result = dbus_bus.get_bus("com.victronenergy.settings")
+            assert result is new_bus
+            assert result is not old_bus
+
+    def test_settings_key_shared_across_callers(self):
+        bus = FakeBus()
+        with patch.object(dbus_bus, 'SystemBus', return_value=bus), \
+             patch.dict(os.environ, {}, clear=True):
+            from_role_a = dbus_bus.get_bus("com.victronenergy.settings")
+            from_role_b = dbus_bus.get_bus("com.victronenergy.settings")
+            from_ble_svc = dbus_bus.get_bus("com.victronenergy.settings")
+            assert from_role_a is from_role_b is from_ble_svc
+
+    def test_uses_session_bus_when_env_set(self):
+        bus = FakeBus()
+        with patch.object(dbus_bus, 'SessionBus', return_value=bus) as mock_session, \
+             patch.object(dbus_bus, 'SystemBus') as mock_system, \
+             patch.dict(os.environ, {"DBUS_SESSION_BUS_ADDRESS": "unix:path=/tmp/test"}):
+            result = dbus_bus.get_bus("test.key")
+            mock_session.assert_called_once()
+            mock_system.assert_not_called()
+            assert result is bus
+
+    def test_uses_system_bus_when_env_not_set(self):
+        bus = FakeBus()
+        with patch.object(dbus_bus, 'SystemBus', return_value=bus) as mock_system, \
+             patch.object(dbus_bus, 'SessionBus') as mock_session, \
+             patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("DBUS_SESSION_BUS_ADDRESS", None)
+            result = dbus_bus.get_bus("test.key")
+            mock_system.assert_called_once()
+            mock_session.assert_not_called()
+            assert result is bus
+
+    def test_role_service_keys_dont_collide(self):
+        """Simulates two Mopeka tank services — each must get its own bus."""
+        buses = [FakeBus(), FakeBus()]
+        call_count = 0
+
+        def make_bus():
+            nonlocal call_count
+            b = buses[call_count]
+            call_count += 1
+            return b
+
+        with patch.object(dbus_bus, 'SystemBus', side_effect=make_bus), \
+             patch.dict(os.environ, {}, clear=True):
+            tank_a = dbus_bus.get_bus("com.victronenergy.tank.mopeka_aaa")
+            tank_b = dbus_bus.get_bus("com.victronenergy.tank.mopeka_bbb")
+            assert tank_a is not tank_b
+
+            # Re-fetching same key returns cached
+            assert dbus_bus.get_bus("com.victronenergy.tank.mopeka_aaa") is tank_a
+            assert dbus_bus.get_bus("com.victronenergy.tank.mopeka_bbb") is tank_b
+
+    def test_connected_bus_is_not_replaced(self):
+        """A connected bus should never be replaced."""
+        bus = FakeBus(connected=True)
+        dbus_bus._bus_instances["key"] = bus
+
+        new_bus = FakeBus()
+        with patch.object(dbus_bus, 'SystemBus', return_value=new_bus), \
+             patch.dict(os.environ, {}, clear=True):
+            result = dbus_bus.get_bus("key")
+            assert result is bus  # original, not replaced

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_mopeka_scaling.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_mopeka_scaling.py
@@ -1,0 +1,401 @@
+"""
+Tests for Mopeka sensor data parsing and scaling calculations.
+
+Uses raw BLE advertisement captures from real Mopeka Pro LPG sensors on
+a 2025 Airstream Flying Cloud 30' FB Bunk (two 30lb steel propane tanks).
+
+Verifies:
+  - Register parsing matches the C implementation (mopeka.c)
+  - Temperature-dependent polynomial scaling of RawValue
+  - Butane ratio scaling matches C: both coefficients multiplied by r
+  - End-to-end pipeline: raw bytes → scaled cm → level percentage
+"""
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock
+
+# Mock D-Bus modules before any imports that need them
+for _mod in ['dbus', 'dbus.mainloop.glib', 'vedbus', 'settingsdevice', 'dbusmonitor']:
+    sys.modules[_mod] = MagicMock()
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'ext'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'ext', 'velib_python'))
+
+from ble_device_mopeka import BleDeviceMopeka
+from ble_role_tank import BleRoleTank
+from ble_role import BleRole
+
+
+# Raw advertisement captures from btmon (manufacturer_id=0x0059 payload only)
+# Sensor: Mopeka Pro LPG, HW ID 3
+RAW_STEEL_R = [
+    # CB:15:7D:29:61:44 — NIC bytes at [5:8] = 29 61 44
+    bytes.fromhex('03593adb80296144e6f9'),
+    bytes.fromhex('03593adb80296144edfd'),
+    bytes.fromhex('03593adb80296144e900'),
+    bytes.fromhex('035a3adb80296144ebf9'),
+    bytes.fromhex('03593adb80296144ebfb'),
+    bytes.fromhex('03593adb80296144f0f6'),
+]
+
+RAW_STEEL_L = [
+    # F4:5F:E6:A3:DA:F4 — NIC bytes at [5:8] = a3 da f4
+    bytes.fromhex('03593bdc80a3daf40419'),
+    bytes.fromhex('03593bdc80a3daf40416'),
+    bytes.fromhex('035a3bdc80a3daf40019'),
+    bytes.fromhex('035a3bdc80a3daf4fd12'),
+    bytes.fromhex('03593bdc80a3daf4001b'),
+    bytes.fromhex('03593bdc80a3daf40619'),
+    bytes.fromhex('03593bdd80a3daf40419'),
+]
+
+
+class TestMopekaRegisterParsing(unittest.TestCase):
+    """Test that register parsing extracts correct values from raw bytes."""
+
+    @classmethod
+    def setUpClass(cls):
+        BleRole.load_classes(os.path.dirname(os.path.abspath(__file__)))
+
+    def _make_device(self, mac, raw):
+        dev = BleDeviceMopeka(mac)
+        dev.configure(raw)
+        dev._load_configuration()
+        return dev
+
+    def test_steel_r_parsing(self):
+        raw = RAW_STEEL_R[0]  # 03593adb80296144e6f9
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+
+        self.assertEqual(parsed['tank']['HardwareID'], 3)
+        self.assertEqual(parsed['tank']['TankLevelExtension'], 0)
+        self.assertEqual(parsed['tank']['BatteryVoltage'], 89 / 32)  # 2.78125
+        self.assertEqual(parsed['tank']['Temperature'], 18.0)  # 58 - 40
+        self.assertEqual(parsed['tank']['RawValue'], 219)
+
+        self.assertNotIn('temperature', parsed,
+                         "Mopeka should not have a separate temperature role")
+
+    def test_single_tank_role_only(self):
+        """Mopeka creates one tank service, not separate temperature/movement services.
+        Matches C implementation which exposes /Temperature on the tank service."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        self.assertEqual(list(parsed.keys()), ['tank'])
+
+    def test_steel_l_parsing(self):
+        raw = RAW_STEEL_L[0]  # 03593bdc80a3daf40419
+        dev = self._make_device('f45fe6a3daf4', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+
+        self.assertEqual(parsed['tank']['HardwareID'], 3)
+        self.assertEqual(parsed['tank']['Temperature'], 19.0)  # 59 - 40
+        self.assertEqual(parsed['tank']['RawValue'], 220)
+
+    def test_steel_l_raw_221(self):
+        raw = RAW_STEEL_L[6]  # 03593bdd80... — RawValue should be 221
+        dev = self._make_device('f45fe6a3daf4', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        self.assertEqual(parsed['tank']['RawValue'], 221)
+
+    def test_temperature_in_tank_role(self):
+        """Temperature must be in the tank role data for scaling calculation.
+        The C implementation (mopeka_xlate_level) reads Temperature from the
+        flat VeItem tree; the Python port must include it in the tank role."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        self.assertIn('Temperature', parsed['tank'],
+                      "Temperature must be available in tank role for scaling")
+
+    def test_nic_check_rejects_wrong_mac(self):
+        raw = RAW_STEEL_R[0]  # NIC = 29 61 44
+        dev = self._make_device('aabbccddeeff', raw)
+        dev.configure(raw)
+        dev._load_configuration()
+        self.assertFalse(dev.check_manufacturer_data(raw))
+
+    def test_nic_check_accepts_correct_mac(self):
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        self.assertTrue(dev.check_manufacturer_data(raw))
+
+    def test_all_steel_r_samples_pass_nic(self):
+        for i, raw in enumerate(RAW_STEEL_R):
+            dev = self._make_device('cb157d296144', raw)
+            self.assertTrue(dev.check_manufacturer_data(raw),
+                            f"Steel R sample {i} failed NIC check")
+
+    def test_all_steel_l_samples_pass_nic(self):
+        for i, raw in enumerate(RAW_STEEL_L):
+            dev = self._make_device('f45fe6a3daf4', raw)
+            self.assertTrue(dev.check_manufacturer_data(raw),
+                            f"Steel L sample {i} failed NIC check")
+
+    def test_cross_contamination_rejected(self):
+        """Steel R data must NOT pass Steel L's NIC check, and vice versa."""
+        raw_r = RAW_STEEL_R[0]
+        raw_l = RAW_STEEL_L[0]
+
+        dev_r = self._make_device('cb157d296144', raw_r)
+        dev_l = self._make_device('f45fe6a3daf4', raw_l)
+
+        self.assertFalse(dev_r.check_manufacturer_data(raw_l),
+                         "Steel R device must reject Steel L data")
+        self.assertFalse(dev_l.check_manufacturer_data(raw_r),
+                         "Steel L device must reject Steel R data")
+
+    def test_battery_voltage_variation(self):
+        """Battery voltage should vary between samples (byte 1 = 0x59 or 0x5a)."""
+        dev = self._make_device('f45fe6a3daf4', RAW_STEEL_L[0])
+        voltages = set()
+        for raw in RAW_STEEL_L:
+            parsed = dev._parse_manufacturer_data(raw)
+            voltages.add(parsed['tank']['BatteryVoltage'])
+        self.assertTrue(len(voltages) >= 2,
+                        f"Expected battery voltage variation, got {voltages}")
+
+
+class TestMopekaScaling(unittest.TestCase):
+    """Test the temperature-dependent polynomial scaling of RawValue."""
+
+    @classmethod
+    def setUpClass(cls):
+        BleRole.load_classes(os.path.dirname(os.path.abspath(__file__)))
+
+    def _make_device(self, mac, raw):
+        dev = BleDeviceMopeka(mac)
+        dev.configure(raw)
+        dev._load_configuration()
+        return dev
+
+    def _mock_role_service(self, butane_ratio=0, fluid_type=8):
+        svc = {
+            'ButaneRatio': butane_ratio,
+            'FluidType': fluid_type,
+            'BatteryVoltage': 2.78125,
+        }
+        mock = MagicMock()
+        mock.__getitem__ = lambda self_m, key: svc[key]
+        mock.ble_role = MagicMock()
+        mock.ble_role.NAME = 'tank'
+        return mock
+
+    def test_butane_scale_zero_ratio(self):
+        """With ButaneRatio=0, butane contribution must be exactly 0.
+        Matches C: mopeka_coefs_butane[0] * r + mopeka_coefs_butane[1] * r * temp"""
+        dev = BleDeviceMopeka('000000000000')
+        result = dev._get_scale_butane(0, 58)
+        self.assertEqual(result, 0.0)
+
+    def test_butane_scale_nonzero_ratio(self):
+        """With ButaneRatio=50, verify against C formula."""
+        dev = BleDeviceMopeka('000000000000')
+        r = 50 / 100.0
+        temp = 58
+        expected = 0.03615 * r + 0.000815 * r * temp
+        result = dev._get_scale_butane(50, temp)
+        self.assertAlmostEqual(result, expected, places=10)
+
+    def test_butane_scale_full_ratio(self):
+        dev = BleDeviceMopeka('000000000000')
+        r = 1.0
+        temp = 58
+        expected = 0.03615 * r + 0.000815 * r * temp
+        result = dev._get_scale_butane(100, temp)
+        self.assertAlmostEqual(result, expected, places=10)
+
+    def test_scaling_steel_r(self):
+        """Verify scaling matches C mopeka_xlate_level for Steel R raw capture."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        role_svc = self._mock_role_service(butane_ratio=0)
+        dev.update_data(role_svc, tank_data)
+
+        # C calculation: temp=58, raw=219, coefs_lpg, butane_scale=0
+        # scale = 0.573045 + (-0.002822 * 58) + (-0.00000535 * 58 * 58) = 0.391372
+        # RawValue = (219 * 0.391372) / 10 = 8.5710
+        self.assertAlmostEqual(tank_data['RawValue'], 8.571, places=2)
+
+    def test_scaling_steel_l(self):
+        """Verify scaling for Steel L (different temperature and raw value)."""
+        raw = RAW_STEEL_L[0]  # temp=19°C, raw=220
+        dev = self._make_device('f45fe6a3daf4', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        role_svc = self._mock_role_service(butane_ratio=0)
+        dev.update_data(role_svc, tank_data)
+
+        # temp=59, raw=220, coefs_lpg, butane_scale=0
+        # scale = 0.573045 + (-0.002822 * 59) + (-0.00000535 * 59 * 59) = 0.387924
+        # RawValue = (220 * 0.387924) / 10 = 8.5343
+        self.assertAlmostEqual(tank_data['RawValue'], 8.534, places=2)
+
+    def test_scaling_skipped_for_non_tank_role(self):
+        """update_data must be a no-op when called with a non-tank role."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+
+        fake_data = {'Temperature': 18.0, 'BatteryVoltage': 2.78125}
+        original = fake_data.copy()
+
+        temp_svc = MagicMock()
+        temp_svc.ble_role = MagicMock()
+        temp_svc.ble_role.NAME = 'temperature'
+        dev.update_data(temp_svc, fake_data)
+        self.assertEqual(fake_data, original, "Non-tank role data must not be modified")
+
+    def test_sensors_produce_different_values(self):
+        """Steel R and Steel L must produce measurably different scaled values."""
+        dev_r = self._make_device('cb157d296144', RAW_STEEL_R[0])
+        dev_l = self._make_device('f45fe6a3daf4', RAW_STEEL_L[0])
+
+        parsed_r = dev_r._parse_manufacturer_data(RAW_STEEL_R[0])
+        parsed_l = dev_l._parse_manufacturer_data(RAW_STEEL_L[0])
+        tank_r = dict(parsed_r['tank'])
+        tank_l = dict(parsed_l['tank'])
+
+        role_svc = self._mock_role_service(butane_ratio=0)
+        dev_r.update_data(role_svc, tank_r)
+        dev_l.update_data(role_svc, tank_l)
+
+        self.assertNotEqual(tank_r['RawValue'], tank_l['RawValue'],
+                            "Steel R and L must have different scaled values")
+        self.assertNotEqual(parsed_r['tank']['Temperature'],
+                            parsed_l['tank']['Temperature'],
+                            "Steel R and L must have different temperatures")
+
+
+class TestMopekaEndToEnd(unittest.TestCase):
+    """Test the full pipeline: raw bytes → scaling → level calculation."""
+
+    @classmethod
+    def setUpClass(cls):
+        BleRole.load_classes(os.path.dirname(os.path.abspath(__file__)))
+
+    def _make_device(self, mac, raw):
+        dev = BleDeviceMopeka(mac)
+        dev.configure(raw)
+        dev._load_configuration()
+        return dev
+
+    def _mock_role_service(self, raw_empty=0.0, raw_full=40.4, capacity=0.02649788):
+        return {
+            'ButaneRatio': 0,
+            'FluidType': 8,
+            'BatteryVoltage': 2.78125,
+            'RawValue': 0.0,
+            'RawValueEmpty': raw_empty,
+            'RawValueFull': raw_full,
+            'Capacity': capacity,
+            'Shape': '',
+            'Level': 0,
+            'Remaining': 0.0,
+        }
+
+    def test_steel_r_full_pipeline(self):
+        """Raw bytes → Mopeka scaling → tank level computation → ~21%."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        role_svc_mock = MagicMock()
+        role_svc_mock.__getitem__ = lambda s, k: {'ButaneRatio': 0, 'FluidType': 8}[k]
+        role_svc_mock.ble_role = MagicMock()
+        role_svc_mock.ble_role.NAME = 'tank'
+
+        # Step 1: Device scaling (must run first, per C xlate pattern)
+        dev.update_data(role_svc_mock, tank_data)
+        scaled_raw = tank_data['RawValue']
+        self.assertAlmostEqual(scaled_raw, 8.571, places=2)
+
+        # Step 2: Role level computation
+        tank_role = BleRoleTank(config={'flags': []})
+        tank_role._parse_shape_str('')
+        dbus_svc = self._mock_role_service()
+        level, remaining, status = tank_role._compute_level(
+            rawValue=scaled_raw,
+            empty=dbus_svc['RawValueEmpty'],
+            full=dbus_svc['RawValueFull'],
+            capacity=dbus_svc['Capacity'],
+        )
+        self.assertEqual(level, 21)
+        self.assertEqual(status, 0)
+
+    def test_steel_l_full_pipeline(self):
+        """Steel L should also produce ~21% but with different intermediate values."""
+        raw = RAW_STEEL_L[0]
+        dev = self._make_device('f45fe6a3daf4', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        role_svc_mock = MagicMock()
+        role_svc_mock.__getitem__ = lambda s, k: {'ButaneRatio': 0, 'FluidType': 8}[k]
+        role_svc_mock.ble_role = MagicMock()
+        role_svc_mock.ble_role.NAME = 'tank'
+
+        dev.update_data(role_svc_mock, tank_data)
+        scaled_raw = tank_data['RawValue']
+        self.assertAlmostEqual(scaled_raw, 8.534, places=2)
+
+        tank_role = BleRoleTank(config={'flags': []})
+        tank_role._parse_shape_str('')
+        dbus_svc = self._mock_role_service()
+        level, remaining, status = tank_role._compute_level(
+            rawValue=scaled_raw,
+            empty=dbus_svc['RawValueEmpty'],
+            full=dbus_svc['RawValueFull'],
+            capacity=dbus_svc['Capacity'],
+        )
+        self.assertEqual(level, 21)
+        self.assertEqual(status, 0)
+
+    def test_wrong_execution_order_gives_wrong_level(self):
+        """If role update_data runs before device update_data, Level is wrong.
+        This regression test ensures the execution order fix stays in place."""
+        raw = RAW_STEEL_R[0]
+        dev = self._make_device('cb157d296144', raw)
+        parsed = dev._parse_manufacturer_data(raw)
+        tank_data = dict(parsed['tank'])
+
+        # Wrong order: role first (computes Level from UNSCALED RawValue=219)
+        tank_role = BleRoleTank(config={'flags': []})
+        tank_role._parse_shape_str('')
+        dbus_svc = self._mock_role_service()
+        level_wrong, _, _ = tank_role._compute_level(
+            rawValue=float(tank_data['RawValue']),  # 219 (unscaled!)
+            empty=dbus_svc['RawValueEmpty'],
+            full=dbus_svc['RawValueFull'],
+            capacity=dbus_svc['Capacity'],
+        )
+        self.assertEqual(level_wrong, 100,
+                         "Unscaled RawValue should overflow to 100%")
+
+        # Correct order: device first (scales RawValue), then role
+        role_svc_mock = MagicMock()
+        role_svc_mock.__getitem__ = lambda s, k: {'ButaneRatio': 0, 'FluidType': 8}[k]
+        role_svc_mock.ble_role = MagicMock()
+        role_svc_mock.ble_role.NAME = 'tank'
+        dev.update_data(role_svc_mock, tank_data)
+
+        level_correct, _, _ = tank_role._compute_level(
+            rawValue=float(tank_data['RawValue']),  # ~8.57 (scaled)
+            empty=dbus_svc['RawValueEmpty'],
+            full=dbus_svc['RawValueFull'],
+            capacity=dbus_svc['Capacity'],
+        )
+        self.assertEqual(level_correct, 21,
+                         "Scaled RawValue should give ~21%")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_passive_scan.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_passive_scan.py
@@ -1,4 +1,4 @@
-"""Tests for passive BLE scanning with AdvertisementMonitor1 fallback."""
+"""Tests for passive BLE scanning with threaded AdvertisementMonitor1."""
 import sys
 import os
 import types
@@ -75,8 +75,8 @@ class TestPassiveScanOrPatterns(unittest.TestCase):
         self.assertIn(0x1a, flag_bytes, "LE General + BR/EDR Not Supported + Dual-Mode")
 
 
-class TestScanMethodPassiveMode(unittest.TestCase):
-    """Verify _scan() uses passive mode with fallback to active."""
+class TestRunPassiveScan(unittest.TestCase):
+    """Verify _run_passive_scan runs BleakScanner in a thread."""
 
     def _run(self, coro):
         loop = asyncio.new_event_loop()
@@ -92,82 +92,116 @@ class TestScanMethodPassiveMode(unittest.TestCase):
         obj._known_mac = {}
         return obj
 
-    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
     @patch('dbus_ble_sensors.bleak.BleakScanner')
-    def test_scan_uses_passive_mode(self, mock_scanner_cls, mock_sleep):
-        """BleakScanner should be created with scanning_mode='passive'."""
+    def test_passive_scan_uses_correct_params(self, mock_scanner_cls):
+        """BleakScanner in the worker thread should get passive mode + or_patterns."""
         scanner_instance = AsyncMock()
         mock_scanner_cls.return_value = scanner_instance
         scanner_instance.__aenter__ = AsyncMock(return_value=scanner_instance)
         scanner_instance.__aexit__ = AsyncMock(return_value=False)
 
-        self._run(self._make_obj()._scan('hci0'))
+        results = self._run(self._make_obj()._run_passive_scan('hci0'))
 
         mock_scanner_cls.assert_called_once()
         kwargs = mock_scanner_cls.call_args.kwargs
         self.assertEqual(kwargs.get('scanning_mode'), 'passive')
         self.assertEqual(kwargs['bluez']['adapter'], 'hci0')
         self.assertEqual(kwargs['bluez']['or_patterns'], PASSIVE_SCAN_OR_PATTERNS)
+        self.assertIsInstance(results, list)
+
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_passive_scan_collects_results(self, mock_scanner_cls):
+        """Results from detection_callback should be returned."""
+        scanner_instance = AsyncMock()
+        mock_scanner_cls.return_value = scanner_instance
+        scanner_instance.__aenter__ = AsyncMock(return_value=scanner_instance)
+        scanner_instance.__aexit__ = AsyncMock(return_value=False)
+
+        fake_device = MagicMock()
+        fake_ad = MagicMock()
+
+        def simulate_callback(*args, **kwargs):
+            cb = mock_scanner_cls.call_args.kwargs.get('detection_callback')
+            if cb:
+                cb(fake_device, fake_ad)
+            return scanner_instance
+
+        scanner_instance.__aenter__ = AsyncMock(side_effect=simulate_callback)
+
+        results = self._run(self._make_obj()._run_passive_scan('hci0'))
+
+        self.assertEqual(len(results), 1)
+        self.assertIs(results[0][0], fake_device)
+        self.assertIs(results[0][1], fake_ad)
+
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_passive_scan_propagates_error(self, mock_scanner_cls):
+        """If BleakScanner raises, _run_passive_scan should re-raise."""
+        scanner_instance = AsyncMock()
+        mock_scanner_cls.return_value = scanner_instance
+        scanner_instance.__aenter__ = AsyncMock(
+            side_effect=Exception("passive scanning mode requires bluez or_patterns")
+        )
+        scanner_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with self.assertRaises(Exception) as ctx:
+            self._run(self._make_obj()._run_passive_scan('hci0'))
+        self.assertIn("or_patterns", str(ctx.exception))
+
+
+class TestScanMethodFallback(unittest.TestCase):
+    """Verify _scan() falls back to active when passive fails."""
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_obj(self):
+        obj = object.__new__(DbusBleSensors)
+        obj._ignored_mac = {}
+        obj._known_mac = {}
+        return obj
 
     @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
     @patch('dbus_ble_sensors.bleak.BleakScanner')
-    def test_scan_falls_back_to_active_on_passive_failure(self, mock_scanner_cls, mock_sleep):
-        """If passive scan raises, should fall back to active scan."""
-        passive_scanner = AsyncMock()
-        passive_scanner.__aenter__ = AsyncMock(
-            side_effect=Exception("passive scanning mode requires bluez or_patterns")
-        )
-        passive_scanner.__aexit__ = AsyncMock(return_value=False)
-
+    def test_falls_back_to_active_on_passive_failure(self, mock_scanner_cls, mock_sleep):
+        """If _run_passive_scan raises, should fall back to active BleakScanner."""
         active_scanner = AsyncMock()
         active_scanner.__aenter__ = AsyncMock(return_value=active_scanner)
         active_scanner.__aexit__ = AsyncMock(return_value=False)
+        mock_scanner_cls.return_value = active_scanner
 
-        mock_scanner_cls.side_effect = [passive_scanner, active_scanner]
+        obj = self._make_obj()
+        with patch.object(obj, '_run_passive_scan', new_callable=AsyncMock,
+                          side_effect=Exception("passive failed")):
+            self._run(obj._scan('hci0'))
 
-        self._run(self._make_obj()._scan('hci0'))
-
-        self.assertEqual(mock_scanner_cls.call_count, 2,
-                         "Should create two scanners: passive attempt then active fallback")
-
-        first_kwargs = mock_scanner_cls.call_args_list[0].kwargs
-        self.assertEqual(first_kwargs.get('scanning_mode'), 'passive')
-
-        second_kwargs = mock_scanner_cls.call_args_list[1].kwargs
-        self.assertNotIn('scanning_mode', second_kwargs,
-                         "Active fallback should not set scanning_mode")
-        self.assertEqual(second_kwargs['bluez']['adapter'], 'hci0')
-
-    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
-    @patch('dbus_ble_sensors.bleak.BleakScanner')
-    def test_scan_passes_detection_callback(self, mock_scanner_cls, mock_sleep):
-        """BleakScanner should receive a callable detection_callback."""
-        scanner_instance = AsyncMock()
-        mock_scanner_cls.return_value = scanner_instance
-        scanner_instance.__aenter__ = AsyncMock(return_value=scanner_instance)
-        scanner_instance.__aexit__ = AsyncMock(return_value=False)
-
-        self._run(self._make_obj()._scan('hci0'))
-
-        callback = mock_scanner_cls.call_args.kwargs.get('detection_callback')
-        self.assertIsNotNone(callback)
-        self.assertTrue(callable(callback))
-
-    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
-    @patch('dbus_ble_sensors.bleak.BleakScanner')
-    def test_scan_adapter_passed_in_bluez_dict(self, mock_scanner_cls, mock_sleep):
-        """Adapter name should be in bluez dict, not as a top-level kwarg."""
-        scanner_instance = AsyncMock()
-        mock_scanner_cls.return_value = scanner_instance
-        scanner_instance.__aenter__ = AsyncMock(return_value=scanner_instance)
-        scanner_instance.__aexit__ = AsyncMock(return_value=False)
-
-        self._run(self._make_obj()._scan('hci1'))
-
+        mock_scanner_cls.assert_called_once()
         kwargs = mock_scanner_cls.call_args.kwargs
-        self.assertNotIn('adapter', kwargs,
-                         "adapter should be inside bluez dict, not top-level")
-        self.assertEqual(kwargs['bluez']['adapter'], 'hci1')
+        self.assertNotIn('scanning_mode', kwargs,
+                         "Active fallback should not set scanning_mode")
+        self.assertEqual(kwargs['bluez']['adapter'], 'hci0')
+
+    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_passive_results_processed_by_callback(self, mock_scanner_cls, mock_sleep):
+        """Passive scan results should be fed through _scan_callback."""
+        fake_device = MagicMock()
+        fake_device.address = 'AA:BB:CC:DD:EE:FF'
+        fake_device.name = 'TestDevice'
+        fake_ad = MagicMock()
+        fake_ad.manufacturer_data = None
+
+        obj = self._make_obj()
+        with patch.object(obj, '_run_passive_scan', new_callable=AsyncMock,
+                          return_value=[(fake_device, fake_ad)]):
+            self._run(obj._scan('hci0'))
+
+        self.assertIn('aabbccddeeff', obj._ignored_mac,
+                       "Device without manufacturer data should be ignored")
 
 
 if __name__ == '__main__':

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_passive_scan.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_passive_scan.py
@@ -1,0 +1,174 @@
+"""Tests for passive BLE scanning with AdvertisementMonitor1 fallback."""
+import sys
+import os
+import types
+from unittest.mock import MagicMock
+
+# ── Mock Venus OS modules unavailable outside the target device ──────
+# These must be injected before importing dbus_ble_sensors because its
+# import chain (ble_device -> dbus_ble_service -> vedbus, etc.) would
+# fail on any non-Venus-OS machine.
+
+_MOCK_MODULES = [
+    'dbus', 'dbus.mainloop', 'dbus.mainloop.glib', 'dbus.service',
+    'gi', 'gi.repository', 'gi.repository.GLib',
+    'gbulb',
+    'vedbus', 'logger', 've_utils',
+    'dbus_settings_service', 'dbus_ble_service', 'dbus_role_service',
+    'ble_device', 'ble_role', 've_types', 'man_id', 'conf',
+]
+
+for mod_name in _MOCK_MODULES:
+    sys.modules.setdefault(mod_name, MagicMock())
+
+# Provide specific attributes the import chain expects
+sys.modules['dbus'].SystemBus = MagicMock
+sys.modules['dbus'].SessionBus = MagicMock
+sys.modules['dbus.mainloop.glib'].DBusGMainLoop = MagicMock()
+sys.modules['gbulb'].install = MagicMock()
+sys.modules['gbulb'].GLibEventLoopPolicy = type('GLibEventLoopPolicy', (), {})
+sys.modules['logger'].setup_logging = MagicMock()
+sys.modules['conf'].SCAN_TIMEOUT = 15
+sys.modules['conf'].SCAN_SLEEP = 5
+sys.modules['conf'].IGNORED_DEVICES_TIMEOUT = 600
+sys.modules['conf'].DEVICE_SERVICES_TIMEOUT = 1800
+sys.modules['conf'].PROCESS_VERSION = '1.1.0'
+sys.modules['man_id'].MAN_NAMES = {}
+sys.modules['ble_device'].BleDevice = type('BleDevice', (), {'DEVICE_CLASSES': {}, 'load_classes': classmethod(lambda cls, p: None)})
+sys.modules['ble_role'].BleRole = type('BleRole', (), {'load_classes': classmethod(lambda cls, p: None)})
+sys.modules['dbus_ble_service'].DbusBleService = MagicMock
+
+# ── Now safe to import ───────────────────────────────────────────────
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'ext'))
+
+import unittest
+from unittest.mock import patch, AsyncMock
+import asyncio
+
+from dbus_ble_sensors import DbusBleSensors, PASSIVE_SCAN_OR_PATTERNS
+from bleak.assigned_numbers import AdvertisementDataType
+
+
+class TestPassiveScanOrPatterns(unittest.TestCase):
+    """Verify the OR patterns constant is well-formed."""
+
+    def test_patterns_not_empty(self):
+        self.assertGreater(len(PASSIVE_SCAN_OR_PATTERNS), 0)
+
+    def test_patterns_are_tuples(self):
+        for pat in PASSIVE_SCAN_OR_PATTERNS:
+            self.assertIsInstance(pat, tuple)
+            self.assertEqual(len(pat), 3, f"Pattern {pat} should be (offset, ad_type, value)")
+
+    def test_patterns_use_flags_ad_type(self):
+        for offset, ad_type, value in PASSIVE_SCAN_OR_PATTERNS:
+            self.assertEqual(offset, 0)
+            self.assertEqual(ad_type, AdvertisementDataType.FLAGS)
+            self.assertIsInstance(value, bytes)
+            self.assertEqual(len(value), 1)
+
+    def test_common_flag_values_covered(self):
+        flag_bytes = {pat[2][0] for pat in PASSIVE_SCAN_OR_PATTERNS}
+        self.assertIn(0x06, flag_bytes, "LE General Discoverable + BR/EDR Not Supported")
+        self.assertIn(0x02, flag_bytes, "LE General Discoverable")
+        self.assertIn(0x1a, flag_bytes, "LE General + BR/EDR Not Supported + Dual-Mode")
+
+
+class TestScanMethodPassiveMode(unittest.TestCase):
+    """Verify _scan() uses passive mode with fallback to active."""
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_obj(self):
+        """Create a DbusBleSensors with __init__ bypassed."""
+        obj = object.__new__(DbusBleSensors)
+        obj._ignored_mac = {}
+        obj._known_mac = {}
+        return obj
+
+    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_scan_uses_passive_mode(self, mock_scanner_cls, mock_sleep):
+        """BleakScanner should be created with scanning_mode='passive'."""
+        scanner_instance = AsyncMock()
+        mock_scanner_cls.return_value = scanner_instance
+        scanner_instance.__aenter__ = AsyncMock(return_value=scanner_instance)
+        scanner_instance.__aexit__ = AsyncMock(return_value=False)
+
+        self._run(self._make_obj()._scan('hci0'))
+
+        mock_scanner_cls.assert_called_once()
+        kwargs = mock_scanner_cls.call_args.kwargs
+        self.assertEqual(kwargs.get('scanning_mode'), 'passive')
+        self.assertEqual(kwargs['bluez']['adapter'], 'hci0')
+        self.assertEqual(kwargs['bluez']['or_patterns'], PASSIVE_SCAN_OR_PATTERNS)
+
+    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_scan_falls_back_to_active_on_passive_failure(self, mock_scanner_cls, mock_sleep):
+        """If passive scan raises, should fall back to active scan."""
+        passive_scanner = AsyncMock()
+        passive_scanner.__aenter__ = AsyncMock(
+            side_effect=Exception("passive scanning mode requires bluez or_patterns")
+        )
+        passive_scanner.__aexit__ = AsyncMock(return_value=False)
+
+        active_scanner = AsyncMock()
+        active_scanner.__aenter__ = AsyncMock(return_value=active_scanner)
+        active_scanner.__aexit__ = AsyncMock(return_value=False)
+
+        mock_scanner_cls.side_effect = [passive_scanner, active_scanner]
+
+        self._run(self._make_obj()._scan('hci0'))
+
+        self.assertEqual(mock_scanner_cls.call_count, 2,
+                         "Should create two scanners: passive attempt then active fallback")
+
+        first_kwargs = mock_scanner_cls.call_args_list[0].kwargs
+        self.assertEqual(first_kwargs.get('scanning_mode'), 'passive')
+
+        second_kwargs = mock_scanner_cls.call_args_list[1].kwargs
+        self.assertNotIn('scanning_mode', second_kwargs,
+                         "Active fallback should not set scanning_mode")
+        self.assertEqual(second_kwargs['bluez']['adapter'], 'hci0')
+
+    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_scan_passes_detection_callback(self, mock_scanner_cls, mock_sleep):
+        """BleakScanner should receive a callable detection_callback."""
+        scanner_instance = AsyncMock()
+        mock_scanner_cls.return_value = scanner_instance
+        scanner_instance.__aenter__ = AsyncMock(return_value=scanner_instance)
+        scanner_instance.__aexit__ = AsyncMock(return_value=False)
+
+        self._run(self._make_obj()._scan('hci0'))
+
+        callback = mock_scanner_cls.call_args.kwargs.get('detection_callback')
+        self.assertIsNotNone(callback)
+        self.assertTrue(callable(callback))
+
+    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_scan_adapter_passed_in_bluez_dict(self, mock_scanner_cls, mock_sleep):
+        """Adapter name should be in bluez dict, not as a top-level kwarg."""
+        scanner_instance = AsyncMock()
+        mock_scanner_cls.return_value = scanner_instance
+        scanner_instance.__aenter__ = AsyncMock(return_value=scanner_instance)
+        scanner_instance.__aexit__ = AsyncMock(return_value=False)
+
+        self._run(self._make_obj()._scan('hci1'))
+
+        kwargs = mock_scanner_cls.call_args.kwargs
+        self.assertNotIn('adapter', kwargs,
+                         "adapter should be inside bluez dict, not top-level")
+        self.assertEqual(kwargs['bluez']['adapter'], 'hci1')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_passive_scan.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_passive_scan.py
@@ -47,6 +47,7 @@ from unittest.mock import patch, AsyncMock
 import asyncio
 
 from dbus_ble_sensors import DbusBleSensors, PASSIVE_SCAN_OR_PATTERNS
+import dbus_ble_sensors as _dbus_ble_sensors_mod
 from bleak.assigned_numbers import AdvertisementDataType
 
 
@@ -75,13 +76,15 @@ class TestPassiveScanOrPatterns(unittest.TestCase):
         self.assertIn(0x1a, flag_bytes, "LE General + BR/EDR Not Supported + Dual-Mode")
 
 
-class TestRunPassiveScan(unittest.TestCase):
-    """Verify _run_passive_scan runs BleakScanner in a thread."""
+class TestRunScanners(unittest.TestCase):
+    """Verify _run_scanners: passive-first with per-adapter backoff and active fallback."""
 
-    def _run(self, coro):
+    def _run(self, coro, timeout=10):
         loop = asyncio.new_event_loop()
         try:
-            return loop.run_until_complete(coro)
+            return loop.run_until_complete(asyncio.wait_for(coro, timeout=timeout))
+        except asyncio.TimeoutError:
+            pass
         finally:
             loop.close()
 
@@ -90,74 +93,194 @@ class TestRunPassiveScan(unittest.TestCase):
         obj = object.__new__(DbusBleSensors)
         obj._ignored_mac = {}
         obj._known_mac = {}
+        obj._adapters = ['hci0']
+        obj._scan_buffer = []
+        obj._scan_buffer_lock = __import__('threading').Lock()
+        obj._scanner_stop = __import__('threading').Event()
         return obj
 
     @patch('dbus_ble_sensors.bleak.BleakScanner')
-    def test_passive_scan_uses_correct_params(self, mock_scanner_cls):
-        """BleakScanner in the worker thread should get passive mode + or_patterns."""
+    def test_passive_scanner_uses_correct_params(self, mock_scanner_cls):
+        """BleakScanner should get passive mode + or_patterns."""
+        obj = self._make_obj()
         scanner_instance = AsyncMock()
+        scanner_instance.start = AsyncMock(side_effect=lambda: obj._scanner_stop.set())
         mock_scanner_cls.return_value = scanner_instance
-        scanner_instance.__aenter__ = AsyncMock(return_value=scanner_instance)
-        scanner_instance.__aexit__ = AsyncMock(return_value=False)
 
-        results = self._run(self._make_obj()._run_passive_scan('hci0'))
+        self._run(obj._run_scanners())
 
-        mock_scanner_cls.assert_called_once()
-        kwargs = mock_scanner_cls.call_args.kwargs
+        first_call = mock_scanner_cls.call_args_list[0]
+        kwargs = first_call.kwargs
         self.assertEqual(kwargs.get('scanning_mode'), 'passive')
         self.assertEqual(kwargs['bluez']['adapter'], 'hci0')
         self.assertEqual(kwargs['bluez']['or_patterns'], PASSIVE_SCAN_OR_PATTERNS)
-        self.assertIsInstance(results, list)
 
     @patch('dbus_ble_sensors.bleak.BleakScanner')
-    def test_passive_scan_collects_results(self, mock_scanner_cls):
-        """Results from detection_callback should be returned."""
-        scanner_instance = AsyncMock()
-        mock_scanner_cls.return_value = scanner_instance
-        scanner_instance.__aenter__ = AsyncMock(return_value=scanner_instance)
-        scanner_instance.__aexit__ = AsyncMock(return_value=False)
+    def test_retries_with_backoff_on_failure(self, mock_scanner_cls):
+        """If scanner.start() fails, should retry with exponential backoff."""
+        attempt_count = [0]
 
+        def make_scanner(*args, **kwargs):
+            attempt_count[0] += 1
+            scanner = AsyncMock()
+            if attempt_count[0] == 1:
+                scanner.start = AsyncMock(side_effect=Exception("EBUSY"))
+            else:
+                scanner.start = AsyncMock()
+            return scanner
+
+        mock_scanner_cls.side_effect = make_scanner
+
+        obj = self._make_obj()
+
+        async def run():
+            async def stopper():
+                while attempt_count[0] < 2:
+                    await asyncio.sleep(0.1)
+                obj._scanner_stop.set()
+            await asyncio.gather(obj._run_scanners(), stopper())
+
+        self._run(run())
+
+        self.assertGreaterEqual(attempt_count[0], 2,
+            "Should have retried after first failure")
+
+    @patch('dbus_ble_sensors.DbusBleSensors._power_cycle_adapter', new_callable=AsyncMock)
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_power_cycles_before_active_fallback(self, mock_scanner_cls, mock_power_cycle):
+        """After MAX_PASSIVE_RETRIES, should power-cycle and retry passive before active."""
+        attempt_count = [0]
+        modes_seen = []
+
+        def make_scanner(*args, **kwargs):
+            attempt_count[0] += 1
+            mode = kwargs.get('scanning_mode')
+            modes_seen.append(mode)
+            scanner = AsyncMock()
+            if mode == 'passive':
+                scanner.start = AsyncMock(side_effect=Exception("EBUSY"))
+            else:
+                def stop_after_active():
+                    obj._scanner_stop.set()
+                scanner.start = AsyncMock()
+                scanner.stop = AsyncMock(side_effect=stop_after_active)
+            return scanner
+
+        mock_scanner_cls.side_effect = make_scanner
+
+        obj = self._make_obj()
+
+        with patch.object(_dbus_ble_sensors_mod, 'SCANNER_INITIAL_BACKOFF', 0), \
+             patch.object(_dbus_ble_sensors_mod, 'SCANNER_MAX_BACKOFF', 0), \
+             patch.object(_dbus_ble_sensors_mod, 'SCANNER_MAX_PASSIVE_RETRIES', 2), \
+             patch.object(_dbus_ble_sensors_mod, 'SCANNER_ACTIVE_CYCLE_DURATION', 0):
+            self._run(obj._run_scanners(), timeout=10)
+
+        mock_power_cycle.assert_called_once_with('hci0')
+        passive_count = sum(1 for m in modes_seen if m == 'passive')
+        active_count = sum(1 for m in modes_seen if m is None)
+        self.assertGreaterEqual(passive_count, 4,
+            "Should try passive 2x, power-cycle, then passive 2x more before active")
+        self.assertGreaterEqual(active_count, 1,
+            "Should fall back to active only after power-cycle + passive retries fail")
+
+    @patch('dbus_ble_sensors.DbusBleSensors._power_cycle_adapter', new_callable=AsyncMock)
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_power_cycle_recovers_passive(self, mock_scanner_cls, mock_power_cycle):
+        """If power-cycle clears the HCI state, passive should succeed without active."""
+        attempt_count = [0]
+        modes_seen = []
+
+        def make_scanner(*args, **kwargs):
+            attempt_count[0] += 1
+            mode = kwargs.get('scanning_mode')
+            modes_seen.append(mode)
+            scanner = AsyncMock()
+            # Fail passive 2 times (pre-power-cycle), then succeed
+            if mode == 'passive' and attempt_count[0] <= 2:
+                scanner.start = AsyncMock(side_effect=Exception("EBUSY"))
+            else:
+                scanner.start = AsyncMock(side_effect=lambda: obj._scanner_stop.set())
+            return scanner
+
+        mock_scanner_cls.side_effect = make_scanner
+
+        obj = self._make_obj()
+
+        with patch.object(_dbus_ble_sensors_mod, 'SCANNER_INITIAL_BACKOFF', 0), \
+             patch.object(_dbus_ble_sensors_mod, 'SCANNER_MAX_BACKOFF', 0), \
+             patch.object(_dbus_ble_sensors_mod, 'SCANNER_MAX_PASSIVE_RETRIES', 2):
+            self._run(obj._run_scanners(), timeout=10)
+
+        mock_power_cycle.assert_called_once_with('hci0')
+        active_count = sum(1 for m in modes_seen if m is None)
+        self.assertEqual(active_count, 0,
+            "Should never reach active mode when power-cycle recovers passive")
+
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_multiple_adapters(self, mock_scanner_cls):
+        """Should start a scanner per adapter."""
+        obj = self._make_obj()
+        obj._adapters = ['hci0', 'hci1']
+        started = [0]
+
+        def make_scanner(*args, **kwargs):
+            s = AsyncMock()
+            def on_start():
+                started[0] += 1
+                if started[0] >= len(obj._adapters):
+                    obj._scanner_stop.set()
+            s.start = AsyncMock(side_effect=on_start)
+            return s
+
+        mock_scanner_cls.side_effect = make_scanner
+
+        self._run(obj._run_scanners())
+
+        adapters_used = [c.kwargs['bluez']['adapter'] for c in mock_scanner_cls.call_args_list]
+        self.assertIn('hci0', adapters_used)
+        self.assertIn('hci1', adapters_used)
+
+    @patch('dbus_ble_sensors.bleak.BleakScanner')
+    def test_collects_advertisements_to_buffer(self, mock_scanner_cls):
+        """detection_callback should append to _scan_buffer."""
+        obj = self._make_obj()
         fake_device = MagicMock()
         fake_ad = MagicMock()
 
-        def simulate_callback(*args, **kwargs):
+        scanner_instance = AsyncMock()
+
+        def on_start():
             cb = mock_scanner_cls.call_args.kwargs.get('detection_callback')
             if cb:
                 cb(fake_device, fake_ad)
-            return scanner_instance
+            obj._scanner_stop.set()
 
-        scanner_instance.__aenter__ = AsyncMock(side_effect=simulate_callback)
+        scanner_instance.start = AsyncMock(side_effect=on_start)
+        mock_scanner_cls.return_value = scanner_instance
 
-        results = self._run(self._make_obj()._run_passive_scan('hci0'))
+        self._run(obj._run_scanners())
 
-        self.assertEqual(len(results), 1)
-        self.assertIs(results[0][0], fake_device)
-        self.assertIs(results[0][1], fake_ad)
+        self.assertEqual(len(obj._scan_buffer), 1)
+        self.assertIs(obj._scan_buffer[0][0], fake_device)
+        self.assertIs(obj._scan_buffer[0][1], fake_ad)
 
     @patch('dbus_ble_sensors.bleak.BleakScanner')
-    def test_passive_scan_propagates_error(self, mock_scanner_cls):
-        """If BleakScanner raises, _run_passive_scan should re-raise."""
+    def test_starts_passive_not_active(self, mock_scanner_cls):
+        """Initial scanner should always be passive mode."""
+        obj = self._make_obj()
         scanner_instance = AsyncMock()
+        scanner_instance.start = AsyncMock(side_effect=lambda: obj._scanner_stop.set())
         mock_scanner_cls.return_value = scanner_instance
-        scanner_instance.__aenter__ = AsyncMock(
-            side_effect=Exception("passive scanning mode requires bluez or_patterns")
-        )
-        scanner_instance.__aexit__ = AsyncMock(return_value=False)
 
-        with self.assertRaises(Exception) as ctx:
-            self._run(self._make_obj()._run_passive_scan('hci0'))
-        self.assertIn("or_patterns", str(ctx.exception))
+        self._run(obj._run_scanners())
+
+        first_call = mock_scanner_cls.call_args_list[0]
+        self.assertEqual(first_call.kwargs.get('scanning_mode'), 'passive')
 
 
-class TestScanMethodFallback(unittest.TestCase):
-    """Verify _scan() falls back to active when passive fails."""
-
-    def _run(self, coro):
-        loop = asyncio.new_event_loop()
-        try:
-            return loop.run_until_complete(coro)
-        finally:
-            loop.close()
+class TestProcessAdvertisement(unittest.TestCase):
+    """Verify _process_advertisement handles device/advertisement data."""
 
     def _make_obj(self):
         obj = object.__new__(DbusBleSensors)
@@ -165,30 +288,7 @@ class TestScanMethodFallback(unittest.TestCase):
         obj._known_mac = {}
         return obj
 
-    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
-    @patch('dbus_ble_sensors.bleak.BleakScanner')
-    def test_falls_back_to_active_on_passive_failure(self, mock_scanner_cls, mock_sleep):
-        """If _run_passive_scan raises, should fall back to active BleakScanner."""
-        active_scanner = AsyncMock()
-        active_scanner.__aenter__ = AsyncMock(return_value=active_scanner)
-        active_scanner.__aexit__ = AsyncMock(return_value=False)
-        mock_scanner_cls.return_value = active_scanner
-
-        obj = self._make_obj()
-        with patch.object(obj, '_run_passive_scan', new_callable=AsyncMock,
-                          side_effect=Exception("passive failed")):
-            self._run(obj._scan('hci0'))
-
-        mock_scanner_cls.assert_called_once()
-        kwargs = mock_scanner_cls.call_args.kwargs
-        self.assertNotIn('scanning_mode', kwargs,
-                         "Active fallback should not set scanning_mode")
-        self.assertEqual(kwargs['bluez']['adapter'], 'hci0')
-
-    @patch('dbus_ble_sensors.asyncio.sleep', new_callable=AsyncMock)
-    @patch('dbus_ble_sensors.bleak.BleakScanner')
-    def test_passive_results_processed_by_callback(self, mock_scanner_cls, mock_sleep):
-        """Passive scan results should be fed through _scan_callback."""
+    def test_ignores_device_without_manufacturer_data(self):
         fake_device = MagicMock()
         fake_device.address = 'AA:BB:CC:DD:EE:FF'
         fake_device.name = 'TestDevice'
@@ -196,12 +296,9 @@ class TestScanMethodFallback(unittest.TestCase):
         fake_ad.manufacturer_data = None
 
         obj = self._make_obj()
-        with patch.object(obj, '_run_passive_scan', new_callable=AsyncMock,
-                          return_value=[(fake_device, fake_ad)]):
-            self._run(obj._scan('hci0'))
+        obj._process_advertisement(fake_device, fake_ad)
 
-        self.assertIn('aabbccddeeff', obj._ignored_mac,
-                       "Device without manufacturer data should be ignored")
+        self.assertIn('aabbccddeeff', obj._ignored_mac)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Introduces `dbus_bus.get_bus(cache_key)` — a module-level connection cache that maps each well-known D-Bus name to a single `BusConnection`, creating a new one only when the key is missing or the existing connection reports disconnected.
- Eliminates `private=True` bus creation in `DbusRoleService` — each role service now gets a cached connection keyed by its service name (e.g. `com.victronenergy.tank.mopeka_xxx`), preventing leaked connections when devices are re-detected.
- All `DbusSettingsService` instances now share one connection keyed on `com.victronenergy.settings`, instead of each creating its own `SystemBus()`.
- `DbusBleService` and `DbusBleSensors` adapter discovery also use the cache.
- Fixes `KeyError: 'min'` in `add_setting` for settings without min/max (e.g. `Shape` string setting) by using `props.get('min', 0)`.

## Problem

`DbusRoleService` created a `private=True` `BusConnection` per role, and each also instantiated a `DbusSettingsService` with its own `SystemBus()`. Since `dbus-python` `BusConnection` objects created with `DBusGMainLoop` are pinned in memory by C-level GLib watch/timeout references that Python's GC cannot reach, these connections leaked if device objects were garbage-collected and re-detected — eventually risking the per-UID D-Bus connection limit (256 for root).

Additionally, `add_setting` assumed all setting `props` dicts contain `min` and `max` keys, but string-type settings like `Shape` (`VE_HEAP_STR`) correctly omit them, causing a `KeyError` crash during Mopeka tank initialization.

## Approach

This mirrors the `get_bus()` pattern from [dbus-serialbattery #402](https://github.com/Louisvdw/dbus-serialbattery/pull/402):

| Cache key | Before | After |
|---|---|---|
| Role service name | `private=True` new connection per role | 1 cached connection per service name |
| `com.victronenergy.settings` | New `SystemBus()` per `DbusSettingsService` instance | 1 shared connection |
| `com.victronenergy.ble` | Direct `SystemBus()` | 1 cached connection |
| `org.bluez` (adapter discovery) | Direct `SystemBus()` | 1 cached connection |

Each `VeDbusService` still gets its own connection (required because they all register `/`), but the connection is reused if the same service name is requested again.

## Verified on Cerbo GX

- Service stable (218+ seconds, zero errors)
- Both Mopeka tanks: Level=21, Temperature 16-17°C, RawValue ~8.7cm, Battery 2.75V
- 6 Ruuvi temperature + 1 movement service registered
- All services using cached `dbus_bus.SystemBus` connections

## Test plan

- [x] 8 unit tests covering: cache hit/miss, key isolation, reconnection on disconnect, session vs system bus selection, connected bus not replaced
- [x] Existing passive scan tests pass (no regressions)
- [x] Deployed to Cerbo GX — all tank/temperature/Ruuvi services register correctly
- [x] Both Mopeka tanks showing correct Level, Temperature, RawValue, BatteryVoltage
- [x] Zero errors in service log after restart