### PR TITLE
Add curl-based install method alongside opkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,37 @@ Devices currently supported :
 
 ## Installation
 
+### Quick Install (curl)
+
+Run this one-liner on your Venus OS device (SSH as root):
+
+``` bash
+curl -fsSL https://raw.githubusercontent.com/ldenisey/venus-os-dbus-ble-sensors-py/main/install.sh | bash
+```
+
+This installs to `/data/apps/dbus-ble-sensors-py/` which persists across firmware updates automatically. If an existing opkg installation is detected, it will be cleanly removed and replaced (all device settings are preserved).
+
+To update, re-run the same command. To disable:
+
+``` bash
+bash /data/apps/dbus-ble-sensors-py/disable.sh
+```
+
+To re-enable after disabling or a firmware update:
+
+``` bash
+bash /data/apps/dbus-ble-sensors-py/enable.sh
+```
+
+To fully remove:
+
+``` bash
+bash /data/apps/dbus-ble-sensors-py/disable.sh
+rm -rf /data/apps/dbus-ble-sensors-py
+```
+
+### Alternative: opkg Install
+
 Add the [venus-os-configuration opkg feed](https://github.com/ldenisey/venus-os-configuration/blob/main/docs/VenusOS-Opkg_configuration.md#adding-custom-feed), then :
 ``` bash
 opkg install dbus-ble-sensors-py

--- a/disable.sh
+++ b/disable.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Disable dbus-ble-sensors-py (curl install)
+# Stops the service, removes symlinks, cleans rc.local, and restores stock service.
+# Does NOT remove /data/apps/dbus-ble-sensors-py or user settings.
+#
+
+set -e
+
+INSTALL_DIR="/data/apps/dbus-ble-sensors-py"
+SERVICE_NAME="dbus-ble-sensors-py"
+LAUNCHER_NAME="dbus-ble-sensors-py-launcher"
+
+echo ""
+echo "Disabling $SERVICE_NAME..."
+
+# --- Stop and remove service symlinks ---
+
+for svc_name in "$SERVICE_NAME" "$LAUNCHER_NAME"; do
+    if [ -e "/service/$svc_name" ]; then
+        svc -d "/service/$svc_name" 2>/dev/null || true
+    fi
+done
+sleep 1
+
+for svc_name in "$SERVICE_NAME" "$LAUNCHER_NAME"; do
+    rm -rf "/service/$svc_name" 2>/dev/null || true
+done
+
+pkill -f "supervise $SERVICE_NAME" 2>/dev/null || true
+pkill -f "supervise $LAUNCHER_NAME" 2>/dev/null || true
+pkill -f "multilog .* /var/log/$SERVICE_NAME" 2>/dev/null || true
+pkill -f "multilog .* /var/log/$LAUNCHER_NAME" 2>/dev/null || true
+pkill -f "python.*dbus_ble_sensors" 2>/dev/null || true
+
+echo "  Services stopped and symlinks removed"
+
+# --- Clean rc.local ---
+
+if [ -f /data/rc.local ]; then
+    sed -i "/.*dbus-ble-sensors-py.*/d" /data/rc.local 2>/dev/null || true
+    echo "  rc.local cleaned"
+fi
+
+# --- Restore stock dbus-ble-sensors ---
+
+STOCK_START="/opt/victronenergy/dbus-ble-sensors/start-ble-sensors.sh"
+
+if [ -f "$STOCK_START" ]; then
+    /opt/victronenergy/swupdate-scripts/remount-rw.sh 2>/dev/null || true
+
+    sed -i 's|^#exec |exec |g' "$STOCK_START"
+    sed -i '/^svc -d ./d' "$STOCK_START"
+    echo "  Stock start script restored"
+fi
+
+BT_CONFIG="/lib/udev/bt-config"
+BT_REMOVE="/lib/udev/bt-remove"
+
+if [ -f "$BT_CONFIG" ] && grep -q "dbus-ble-sensors-py" "$BT_CONFIG"; then
+    /opt/victronenergy/swupdate-scripts/remount-rw.sh 2>/dev/null || true
+    sed -i 's|/service/dbus-ble-sensors-py |/service/dbus-ble-sensors |g' "$BT_CONFIG"
+    echo "  bt-config restored"
+fi
+
+if [ -f "$BT_REMOVE" ] && grep -q "dbus-ble-sensors-py" "$BT_REMOVE"; then
+    /opt/victronenergy/swupdate-scripts/remount-rw.sh 2>/dev/null || true
+    sed -i '\|^ *svc -d /service/dbus-ble-sensors-py *$|d' "$BT_REMOVE"
+    echo "  bt-remove restored"
+fi
+
+# Restart stock service if bluetooth hardware is present
+if [ -n "$(ls /sys/class/bluetooth 2>/dev/null)" ]; then
+    svc -u /service/dbus-ble-sensors 2>/dev/null || true
+    echo "  Stock dbus-ble-sensors restarted"
+fi
+
+echo ""
+echo "$SERVICE_NAME disabled. Stock BLE service restored."
+echo ""
+echo "Note: Device settings are preserved in com.victronenergy.settings."
+echo "      To completely remove: rm -rf $INSTALL_DIR"
+echo ""

--- a/enable.sh
+++ b/enable.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# Re-enable dbus-ble-sensors-py (curl install)
+# Repairs permissions, recreates service symlinks, updates rc.local.
+# Useful for recovery after a firmware update or if services go missing.
+#
+
+set -e
+
+INSTALL_DIR="/data/apps/dbus-ble-sensors-py"
+SERVICE_NAME="dbus-ble-sensors-py"
+LAUNCHER_NAME="dbus-ble-sensors-py-launcher"
+APP_DIR="$INSTALL_DIR/src/opt/victronenergy/dbus-ble-sensors-py"
+
+echo ""
+echo "Re-enabling $SERVICE_NAME..."
+
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "Error: $INSTALL_DIR not found. Run install.sh first."
+    exit 1
+fi
+
+# --- Fix permissions ---
+
+chmod +x "$INSTALL_DIR"/service/run 2>/dev/null || true
+chmod +x "$INSTALL_DIR"/service/log/run 2>/dev/null || true
+chmod +x "$INSTALL_DIR"/service-launcher/run 2>/dev/null || true
+chmod +x "$INSTALL_DIR"/service-launcher/log/run 2>/dev/null || true
+chmod +x "$INSTALL_DIR"/*.sh 2>/dev/null || true
+echo "  Permissions fixed"
+
+# --- Disable stock service ---
+
+STOCK_START="/opt/victronenergy/dbus-ble-sensors/start-ble-sensors.sh"
+BT_CONFIG="/lib/udev/bt-config"
+BT_REMOVE="/lib/udev/bt-remove"
+
+if [ -f "$STOCK_START" ] && grep -q "^exec " "$STOCK_START"; then
+    /opt/victronenergy/swupdate-scripts/remount-rw.sh 2>/dev/null || true
+    sed -i 's|^exec |#exec |g' "$STOCK_START"
+    sed -i '\|--banner|a\
+svc -d .' "$STOCK_START"
+    echo "  Stock start script disabled"
+fi
+
+if [ -f "$BT_CONFIG" ] && grep -q "/service/dbus-ble-sensors " "$BT_CONFIG"; then
+    /opt/victronenergy/swupdate-scripts/remount-rw.sh 2>/dev/null || true
+    sed -i 's|/service/dbus-ble-sensors |/service/dbus-ble-sensors-py |g' "$BT_CONFIG"
+    echo "  bt-config patched"
+fi
+
+if [ -f "$BT_REMOVE" ] && ! grep -q "dbus-ble-sensors-py" "$BT_REMOVE"; then
+    /opt/victronenergy/swupdate-scripts/remount-rw.sh 2>/dev/null || true
+    sed -i '\|/service/dbus-ble-sensors$|a\
+    svc -d /service/dbus-ble-sensors-py' "$BT_REMOVE"
+    echo "  bt-remove patched"
+fi
+
+if [ -n "$(ls /sys/class/bluetooth 2>/dev/null)" ]; then
+    svc -d /service/dbus-ble-sensors 2>/dev/null || true
+fi
+
+# --- Stop any stale service entries before recreating ---
+
+for svc_name in "$SERVICE_NAME" "$LAUNCHER_NAME"; do
+    if [ -e "/service/$svc_name" ]; then
+        svc -d "/service/$svc_name" 2>/dev/null || true
+    fi
+done
+sleep 1
+
+# Remove stale symlinks or directories
+for svc_name in "$SERVICE_NAME" "$LAUNCHER_NAME"; do
+    rm -rf "/service/$svc_name" 2>/dev/null || true
+done
+
+pkill -f "supervise $SERVICE_NAME" 2>/dev/null || true
+pkill -f "supervise $LAUNCHER_NAME" 2>/dev/null || true
+pkill -f "python.*dbus_ble_sensors" 2>/dev/null || true
+
+# --- Create service symlinks ---
+
+ln -s "$INSTALL_DIR/service" "/service/$SERVICE_NAME"
+ln -s "$INSTALL_DIR/service-launcher" "/service/$LAUNCHER_NAME"
+echo "  Service symlinks created"
+
+# --- Ensure rc.local persistence ---
+
+RC_LOCAL="/data/rc.local"
+if [ ! -f "$RC_LOCAL" ]; then
+    echo "#!/bin/bash" > "$RC_LOCAL"
+    chmod 755 "$RC_LOCAL"
+fi
+
+RC_ENTRY="bash $INSTALL_DIR/enable.sh > $INSTALL_DIR/startup.log 2>&1 &"
+if ! grep -qF "dbus-ble-sensors-py" "$RC_LOCAL"; then
+    echo "$RC_ENTRY" >> "$RC_LOCAL"
+    echo "  Added to rc.local"
+fi
+
+# --- Start services ---
+
+svc -u "/service/$LAUNCHER_NAME" 2>/dev/null || true
+sleep 2
+echo "  Services started"
+
+echo ""
+echo "$SERVICE_NAME enabled."
+echo ""
+svstat "/service/$SERVICE_NAME" 2>/dev/null || true
+svstat "/service/$LAUNCHER_NAME" 2>/dev/null || true
+echo ""

--- a/install.sh
+++ b/install.sh
@@ -41,16 +41,47 @@ fi
 echo ""
 
 # --- Step 2: Ensure git is available ---
+#
+# Venus OS ships with rootfs (/) mounted read-only.  When git is missing
+# we temporarily remount rw, install via opkg, and revert to ro.  An EXIT
+# trap guarantees the rootfs is restored to ro even if opkg fails, the
+# script is interrupted, or a later step exits non-zero.
 
 echo "Step 2: Checking for git..."
 if ! command -v git >/dev/null 2>&1; then
-    echo "  Git not found. Installing..."
-    opkg update >/dev/null 2>&1 || true
-    if ! opkg install git; then
-        echo "Error: Failed to install git."
+    echo "  Git not found. Installing via opkg (temporary remount,rw)..."
+
+    # Only remount if rootfs is currently mounted ro.  On a system that
+    # already happens to have / mounted rw (developer device, etc.) we
+    # leave the mount state alone.
+    if grep -qE '^[^ ]+ / [^ ]+ ro[, ]' /proc/mounts; then
+        if ! mount -o remount,rw /; then
+            echo "Error: Could not remount / read-write to install git."
+            exit 1
+        fi
+        # Restore ro on any exit path (success, opkg failure, ^C, later
+        # step failure).  Mount may already be back to ro by then; that's
+        # fine, the second remount is a no-op.
+        trap 'mount -o remount,ro / 2>/dev/null || true' EXIT
+        REMOUNTED_FOR_GIT=true
+    else
+        REMOUNTED_FOR_GIT=false
+    fi
+
+    if ! opkg update; then
+        echo "Error: opkg update failed.  Check the device's network."
         exit 1
     fi
-    echo "  Git installed"
+    if ! opkg install git; then
+        echo "Error: Failed to install git via opkg."
+        exit 1
+    fi
+
+    if [ "$REMOUNTED_FOR_GIT" = true ]; then
+        mount -o remount,ro / 2>/dev/null || true
+        trap - EXIT
+    fi
+    echo "  Git installed (rootfs returned to read-only)"
 else
     echo "  Git already available"
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+#
+# Remote installer for dbus-ble-sensors-py on Venus OS
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/ldenisey/venus-os-dbus-ble-sensors-py/main/install.sh | bash
+#
+
+set -e
+
+REPO_URL="https://github.com/ldenisey/venus-os-dbus-ble-sensors-py.git"
+INSTALL_DIR="/data/apps/dbus-ble-sensors-py"
+SERVICE_NAME="dbus-ble-sensors-py"
+LAUNCHER_NAME="dbus-ble-sensors-py-launcher"
+APP_DIR="src/opt/victronenergy/dbus-ble-sensors-py"
+VELIB_URL="https://raw.githubusercontent.com/victronenergy/velib_python/refs/heads/master"
+
+echo "========================================"
+echo " dbus-ble-sensors-py Installer"
+echo "========================================"
+echo ""
+
+# --- Preflight checks ---
+
+if [ ! -d "/data" ]; then
+    echo "Error: /data not found. This script must run on Venus OS."
+    exit 1
+fi
+mkdir -p /data/apps
+
+# --- Step 1: Detect and remove opkg installation ---
+
+echo "Step 1: Checking for existing installations..."
+
+if opkg list-installed 2>/dev/null | grep -q "^dbus-ble-sensors-py "; then
+    echo "  Detected opkg installation. Removing to switch to curl-managed install..."
+    echo "  Note: All device settings and configurations are preserved."
+    opkg remove dbus-ble-sensors-py
+    echo "  opkg package removed"
+fi
+echo ""
+
+# --- Step 2: Ensure git is available ---
+
+echo "Step 2: Checking for git..."
+if ! command -v git >/dev/null 2>&1; then
+    echo "  Git not found. Installing..."
+    opkg update >/dev/null 2>&1 || true
+    if ! opkg install git; then
+        echo "Error: Failed to install git."
+        exit 1
+    fi
+    echo "  Git installed"
+else
+    echo "  Git already available"
+fi
+echo ""
+
+# --- Step 3: Clone or update repository ---
+
+echo "Step 3: Setting up repository..."
+
+NEEDS_RESTART=false
+
+if [ -d "$INSTALL_DIR" ]; then
+    cd "$INSTALL_DIR"
+    git config --global --add safe.directory "$INSTALL_DIR" 2>/dev/null || true
+
+    if [ -d .git ]; then
+        CURRENT_REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
+        if [ "$CURRENT_REMOTE" != "$REPO_URL" ]; then
+            git remote set-url origin "$REPO_URL" 2>/dev/null || git remote add origin "$REPO_URL"
+        fi
+        echo "  Fetching latest changes..."
+        git fetch origin
+        LOCAL=$(git rev-parse HEAD 2>/dev/null || echo "none")
+        REMOTE=$(git rev-parse origin/main 2>/dev/null || echo "none")
+        if [ "$LOCAL" != "$REMOTE" ]; then
+            echo "  Updates available. Resetting to latest..."
+            git checkout main 2>/dev/null || git checkout -b main origin/main
+            git reset --hard origin/main
+            NEEDS_RESTART=true
+            echo "  Repository updated"
+        else
+            echo "  Already up to date"
+        fi
+    else
+        echo "  Not a git repository. Converting..."
+        git init
+        git remote add origin "$REPO_URL"
+        git fetch origin
+        git checkout -b main origin/main 2>/dev/null || git checkout main
+        git reset --hard origin/main
+        NEEDS_RESTART=true
+        echo "  Converted to git repository"
+    fi
+else
+    echo "  Cloning repository..."
+    git clone "$REPO_URL" "$INSTALL_DIR"
+    cd "$INSTALL_DIR"
+    git config --global --add safe.directory "$INSTALL_DIR" 2>/dev/null || true
+    echo "  Repository cloned"
+fi
+echo ""
+
+# --- Step 4: Fetch velib_python ---
+
+echo "Step 4: Fetching velib_python dependencies..."
+VELIB_DIR="$INSTALL_DIR/$APP_DIR/ext/velib_python"
+mkdir -p "$VELIB_DIR"
+for f in vedbus.py logger.py ve_utils.py; do
+    wget -q -O "$VELIB_DIR/$f" "$VELIB_URL/$f"
+done
+echo "  velib_python fetched"
+echo ""
+
+# --- Step 5: Disable stock dbus-ble-sensors ---
+
+echo "Step 5: Disabling stock dbus-ble-sensors..."
+
+STOCK_START="/opt/victronenergy/dbus-ble-sensors/start-ble-sensors.sh"
+BT_CONFIG="/lib/udev/bt-config"
+BT_REMOVE="/lib/udev/bt-remove"
+
+disable_stock_service() {
+    if [ -f "$STOCK_START" ]; then
+        if grep -q "^exec " "$STOCK_START"; then
+            /opt/victronenergy/swupdate-scripts/remount-rw.sh 2>/dev/null || true
+            sed -i 's|^exec |#exec |g' "$STOCK_START"
+            sed -i '\|--banner|a\
+svc -d .' "$STOCK_START"
+            echo "  Stock start script disabled"
+        else
+            echo "  Stock start script already disabled"
+        fi
+
+        if [ -n "$(ls /sys/class/bluetooth 2>/dev/null)" ]; then
+            svc -d /service/dbus-ble-sensors 2>/dev/null || true
+        fi
+    else
+        echo "  Stock service not found (may not be installed)"
+    fi
+
+    if [ -f "$BT_CONFIG" ] && grep -q "/service/dbus-ble-sensors " "$BT_CONFIG"; then
+        /opt/victronenergy/swupdate-scripts/remount-rw.sh 2>/dev/null || true
+        sed -i 's|/service/dbus-ble-sensors |/service/dbus-ble-sensors-py |g' "$BT_CONFIG"
+        echo "  bt-config patched"
+    fi
+
+    if [ -f "$BT_REMOVE" ] && ! grep -q "dbus-ble-sensors-py" "$BT_REMOVE"; then
+        /opt/victronenergy/swupdate-scripts/remount-rw.sh 2>/dev/null || true
+        sed -i '\|/service/dbus-ble-sensors$|a\
+    svc -d /service/dbus-ble-sensors-py' "$BT_REMOVE"
+        echo "  bt-remove patched"
+    fi
+}
+
+disable_stock_service
+echo ""
+
+# --- Step 6: Set up service ---
+
+echo "Step 6: Setting up services..."
+
+chmod +x "$INSTALL_DIR"/service/run 2>/dev/null || true
+chmod +x "$INSTALL_DIR"/service/log/run 2>/dev/null || true
+chmod +x "$INSTALL_DIR"/service-launcher/run 2>/dev/null || true
+chmod +x "$INSTALL_DIR"/service-launcher/log/run 2>/dev/null || true
+chmod +x "$INSTALL_DIR"/*.sh 2>/dev/null || true
+
+# Create or update service symlinks
+for svc_name in "$SERVICE_NAME" "$LAUNCHER_NAME"; do
+    link="/service/$svc_name"
+    if [ "$svc_name" = "$SERVICE_NAME" ]; then
+        target="$INSTALL_DIR/service"
+    else
+        target="$INSTALL_DIR/service-launcher"
+    fi
+
+    if [ -L "$link" ]; then
+        rm "$link"
+    elif [ -d "$link" ]; then
+        svc -d "$link" 2>/dev/null || true
+        sleep 1
+        rm -rf "$link"
+    fi
+    ln -s "$target" "$link"
+done
+echo "  Service symlinks created"
+echo ""
+
+# --- Step 7: Persist across reboots via rc.local ---
+
+echo "Step 7: Setting up boot persistence..."
+
+RC_LOCAL="/data/rc.local"
+if [ ! -f "$RC_LOCAL" ]; then
+    echo "#!/bin/bash" > "$RC_LOCAL"
+    chmod 755 "$RC_LOCAL"
+fi
+
+RC_ENTRY="bash $INSTALL_DIR/enable.sh > $INSTALL_DIR/startup.log 2>&1 &"
+if ! grep -qF "dbus-ble-sensors-py" "$RC_LOCAL"; then
+    echo "$RC_ENTRY" >> "$RC_LOCAL"
+    echo "  Added to rc.local"
+else
+    echo "  Already in rc.local"
+fi
+echo ""
+
+# --- Step 8: Start or restart ---
+
+echo "Step 8: Starting services..."
+
+if [ "$NEEDS_RESTART" = true ] || ! svstat "/service/$SERVICE_NAME" 2>/dev/null | grep -q "up"; then
+    svc -u "/service/$LAUNCHER_NAME" 2>/dev/null || true
+    sleep 3
+
+    if svstat "/service/$SERVICE_NAME" 2>/dev/null | grep -q "up"; then
+        echo "  Service started successfully"
+    else
+        echo "  Service may still be starting (launcher controls lifecycle)"
+    fi
+else
+    svc -t "/service/$SERVICE_NAME" 2>/dev/null || true
+    sleep 2
+    echo "  Service restarted"
+fi
+echo ""
+
+# --- Done ---
+
+echo "========================================"
+echo " Installation Complete!"
+echo "========================================"
+echo ""
+echo "Service status:"
+svstat "/service/$SERVICE_NAME" 2>/dev/null || echo "  (not yet supervised)"
+svstat "/service/$LAUNCHER_NAME" 2>/dev/null || echo "  (not yet supervised)"
+echo ""
+echo "View logs:"
+echo "  tail -f /var/log/$SERVICE_NAME/current | tai64nlocal"
+echo ""
+echo "Service management:"
+echo "  svc -u /service/$SERVICE_NAME   # Start"
+echo "  svc -d /service/$SERVICE_NAME   # Stop"
+echo "  svc -t /service/$SERVICE_NAME   # Restart"
+echo ""
+echo "To disable:  bash $INSTALL_DIR/disable.sh"
+echo "To remove:   bash $INSTALL_DIR/disable.sh && rm -rf $INSTALL_DIR"
+echo ""

--- a/service-launcher/log/run
+++ b/service-launcher/log/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+mkdir -p /var/log/dbus-ble-sensors-py-launcher
+exec multilog t s25000 n4 /var/log/dbus-ble-sensors-py-launcher

--- a/service-launcher/run
+++ b/service-launcher/run
@@ -1,0 +1,80 @@
+#!/bin/sh
+#
+# dbus-ble-sensors-py-launcher script (curl install)
+# Monitor dbus setting to start/stop service dbus-ble-sensors-py accordingly.
+#
+echo "*** starting dbus-ble-sensors-py-launcher ***"
+exec 2>&1
+set -e
+
+get_setting() {
+  dbus-send --print-reply=literal --system --type=method_call \
+  --dest=com.victronenergy.settings "$1" com.victronenergy.BusItem.GetValue |
+  awk '/int32/ { print $NF; exit }'
+}
+
+start() {
+  [ "$STATE" = "1" ] && return
+  echo "Starting dbus-ble-sensors-py service..."
+  svc -u /service/dbus-ble-sensors-py
+  STATE="1"
+}
+
+stop() {
+  [ "$STATE" = "0" ] && return
+  echo "Stopping dbus-ble-sensors-py service..."
+  svc -d /service/dbus-ble-sensors-py
+  STATE="0"
+}
+
+quit() {
+  stop
+  [ -n "$FIFO" ] && rm -f "$FIFO"
+  exit 0
+}
+trap 'quit' INT TERM EXIT
+
+# Wait for com.victronenergy.settings to be available
+while :; do
+  if dbus-send --system --type=method_call --print-reply=literal \
+      --dest=org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.ListNames 2>/dev/null |
+      grep -q "com.victronenergy.settings"; then
+    break
+  fi
+  echo "Waiting for com.victronenergy.settings D-Bus service..."
+  sleep 1
+done
+
+# Apply initial state
+STATE=$(svstat /service/dbus-ble-sensors-py 2>/dev/null | awk '/up/ {print 1; exit} /down/ {print 0; exit} END{print 0}')
+setting=$(get_setting /Settings/Services/BleSensors)
+if [ "$setting" = "1" ]; then
+  start
+else
+  stop
+fi
+
+# Listen for PropertiesChanged on /Settings/Services/BleSensors
+FIFO="/tmp/dbus_ble_sensors_pipe.$$"
+rm -f "$FIFO"
+mkfifo "$FIFO"
+dbus-monitor --system \
+  "type='signal',sender='com.victronenergy.settings',path='/Settings/Services/BleSensors',interface='com.victronenergy.BusItem',member='PropertiesChanged'" \
+  "type='signal',sender='com.victronenergy.settings',path='/Settings/Services/BleSensors',interface='com.victronenergy.BusItem',member='ValueChanged'" > "$FIFO" &
+MONITOR_PID=$!
+
+while IFS= read -r line; do
+  case "$line" in
+    *int32* )
+      state=${line##*int32 }
+      case "$state" in
+        1) start ;;
+        0) stop ;;
+        *) ;;
+      esac
+    ;;
+  esac
+done < "$FIFO"
+
+kill "$MONITOR_PID" 2>/dev/null
+quit

--- a/service/log/run
+++ b/service/log/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+mkdir -p /var/log/dbus-ble-sensors-py
+exec multilog t s25000 n4 /var/log/dbus-ble-sensors-py

--- a/service/run
+++ b/service/run
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# daemontools run script for dbus-ble-sensors-py (curl install)
+#
+echo "*** starting dbus-ble-sensors-py ***"
+exec 2>&1
+. /etc/profile.d/profile.sh 2>/dev/null || true
+
+INSTALL_DIR="/data/apps/dbus-ble-sensors-py"
+APP_DIR="$INSTALL_DIR/src/opt/victronenergy/dbus-ble-sensors-py"
+
+get_setting() {
+  dbus-send --print-reply=literal --system --type=method_call \
+  --dest=com.victronenergy.settings "$1" com.victronenergy.BusItem.GetValue |
+  awk '/int32/ { print $NF; exit }'
+}
+
+if ! ls /sys/class/bluetooth/* >/dev/null 2>&1; then
+  echo "Error: No bluetooth device detected, cancelling service launch"
+  svc -d .
+  exit 1
+fi
+
+if [ "$(get_setting /Settings/Services/BleSensors)" != 1 ]; then
+  echo "Error: Bluetooth service deactivated by configuration, cancelling service launch"
+  svc -d .
+  exit 1
+fi
+
+# AdvertisementMonitor1 passive scanning requires bluetoothd with --experimental.
+# Start it if not running; log a note if running without -E.
+if ! pidof bluetoothd > /dev/null 2>&1; then
+  if [ -x /usr/libexec/bluetooth/bluetoothd ]; then
+    echo "Starting bluetoothd with experimental features for passive scanning..."
+    /usr/libexec/bluetooth/bluetoothd -E &
+    sleep 2
+  fi
+elif ! cat /proc/$(pidof bluetoothd)/cmdline 2>/dev/null | tr '\0' ' ' | grep -qE '\-E|--experimental'; then
+  echo "Note: bluetoothd running without --experimental; passive scanning may fall back"
+fi
+
+exec python3 "$APP_DIR/dbus_ble_sensors.py"


### PR DESCRIPTION
## Summary

- Adds an alternative installation method via `curl | bash` one-liner that installs to `/data/apps/dbus-ble-sensors-py/`, avoiding the need for opkg feeds or `remount-rw.sh`
- Automatically detects and migrates from existing opkg installations, preserving all D-Bus settings (device enables, custom names, VRM instances, fluid types, alarms)
- Persists across Venus OS firmware updates via `/data/rc.local` boot hook

## New Files

| File | Purpose |
|------|---------|
| `install.sh` | Curl entrypoint: opkg detection/removal, git clone, velib_python fetch, stock service disable, service symlink setup, rc.local persistence |
| `enable.sh` | Re-enable after disable or firmware update: fix permissions, re-disable stock, recreate symlinks |
| `disable.sh` | Clean disable: stop services, remove symlinks, clean rc.local, restore stock service (preserves settings) |
| `service/run` | daemontools run script with BT/settings checks and bluetoothd -E startup |
| `service/log/run` | Standard multilog for `/var/log/dbus-ble-sensors-py/` |
| `service-launcher/run` | Monitors `/Settings/Services/BleSensors` D-Bus setting to start/stop main service |
| `service-launcher/log/run` | Standard multilog for `/var/log/dbus-ble-sensors-py-launcher/` |

## Test plan

- [x] Fresh curl install on Cerbo GX (no prior install) — verified services start, all devices register
- [x] Migration from opkg install — verified opkg package cleanly removed, settings preserved, curl-managed version starts
- [x] Reboot persistence — verified rc.local calls enable.sh on boot, services come up automatically
- [x] All device types working post-install: SeeLevel tanks + battery, Mopeka LPG, Ruuvi temperature sensors
- [x] Stock `dbus-ble-sensors` correctly disabled and udev scripts patched