### PR TITLE
Add Orion-TR Smart DC-DC converter BLE driver

### DIFF
--- a/docs/ORION-TR-INTEGRATION.md
+++ b/docs/ORION-TR-INTEGRATION.md
@@ -1,0 +1,151 @@
+# Orion-TR Smart integration (`dbus-ble-sensors-py`)
+
+This document describes the Orion-TR Smart driver integrated into
+`venus-os-dbus-ble-sensors-py`.  It handles encrypted BLE advertisements,
+automatic key provisioning, GATT mode-write (on/off), and daily firmware
+refresh — all within the existing scan-loop architecture.
+
+## Architecture overview
+
+```
+BLE advertisement (0x02E1, product 0xA3C0–0xA3DF)
+        │
+        ▼
+ dbus_ble_sensors.py  ──dispatch──▶  BleDeviceOrionTR
+        │                               │
+        │  bleak scanner (hci0/hci2)    ├── victron_ble decrypt + parse
+        │  paused during GATT bursts    ├── dcdc / alternator role flip
+        │  via scan_control.py          ├── /Mode GATT write
+        │                               └── key / firmware provisioning
+        │                                       │
+        ▼                                       ▼
+ com.victronenergy.dcdc.*             orion_tr_key_cli.py (subprocess)
+ or com.victronenergy.alternator.*    ├── PUK CRC auth (97580006)
+ (gui-v2 PageDcDcConverter.qml)       ├── Subscribe 0xEDDB (prime)
+                                      ├── GetValue 0xEC65 (key)
+                                      ├── GetValue 0x0140 (firmware)
+                                      ├── GetValue 0xEDDB (temperature)
+                                      └── GetValue 0x0100 (product id)
+```
+
+### Key design decisions
+
+1. **Subprocess provisioning.**  PUK authentication and VREG reads run in
+   `orion_tr_key_cli.py` as a separate Python process.  This isolates the
+   GATT session from the long-running service's dbus-python / BlueZ state,
+   which otherwise causes corrupt CCCD writes on reconnection (upper byte
+   of the CCCD value drifts into the `0x70–0x79` range after the first
+   cycle, silently disabling device notifications).
+
+2. **`victron_ble` for decryption.**  The upstream `victron_ble` library
+   is vendored under `ext/victron_ble/` with a one-line patch to its
+   `base.py` so it uses `cryptography` (shipped in Venus OS) instead of
+   PyCryptodome (not available).
+
+3. **Scan pause/resume.**  `scan_control.pause_scanning()` /
+   `resume_scanning()` are ref-counted hooks that make the `BleakScanner`
+   yield the adapter during GATT bursts.  The scan loop polls
+   `is_scanning_paused()` every 250 ms inside its active-scan context so
+   it exits within one BLE advertising interval.
+
+4. **Multi-adapter support.**  All GATT paths resolve the device across
+   every BlueZ adapter via `ObjectManager` rather than hard-coding `hci0`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `ble_device_orion_tr.py` | Device driver: dispatch, decode, dcdc↔alternator flip, /Mode write, provision lifecycle, daily refresh |
+| `orion_tr_key_cli.py` | Standalone subprocess: PUK auth + VREG reads for key, firmware, temperature, product id |
+| `orion_tr_gatt.py` | Async GATT register writer for /Mode (paired, encrypted CBOR SetValue) |
+| `orion_tr_key_settings.py` | Silent-setting helpers for `AdvertisementKey` and `FirmwareVersion` |
+| `orion_tr_pin.py` | Pairing passkey resolution: ini → Cerbo setting → default 0 |
+| `ble_role_dcdc.py` | `dcdc` role (D-Bus paths for `PageDcDcConverter.qml`) |
+| `ble_role_alternator.py` | `alternator` role (D-Bus paths for `PageAlternator.qml`) |
+| `scan_control.py` | Ref-counted pause/resume for the BleakScanner loop |
+| `ext/victron_ble/` | Vendored + patched `victron_ble` library |
+
+## D-Bus service paths
+
+Service name: `com.victronenergy.dcdc.orion_tr_<mac12>` (or `.alternator.`
+when the unit is in a charger algorithm).
+
+| Path | Source | Notes |
+|------|--------|-------|
+| `/ProductId` | Advertisement bytes 2–3 | Verified against VREG 0x0100 |
+| `/ProductName` | BlueZ `Device1.Name` | BLE-advertised name (e.g. "Orion Smart HQ20326VVVJ") |
+| `/FirmwareVersion` | VREG 0x0140 via CLI | Decoded as BCD "major.minor" (e.g. "1.10") |
+| `/Dc/In/V` | Advertisement | 0.01 V units |
+| `/Dc/0/Voltage` | Advertisement | 0.01 V units |
+| `/Dc/0/Temperature` | VREG 0xEDDB via CLI | Celsius (0.01 K raw → subtract 273.15). Updated daily. |
+| `/State` | Advertisement | VE.Direct OperationMode enum |
+| `/ErrorCode` | Advertisement | 0 = no error |
+| `/DeviceOffReason` | Advertisement | Bitmask |
+| `/Mode` | Writable (1=On, 4=Off) | Triggers GATT SetValue on VREG 0x0200 |
+| `/Connected` | Always 1 when adverts decode | |
+
+Paths that are published but currently invalid (hidden by gui-v2's
+`preferredVisible: dataItem.valid`): `/Dc/In/I`, `/Dc/In/P`,
+`/Dc/0/Current`, `/Dc/0/Power`.  These are not available from the
+advertisement payload.  The standalone driver also leaves them blank.
+
+## Configuration
+
+### Advertisement key (automatic)
+
+On first advertisement from an Orion-TR that has no key cached, the
+driver pauses scanning and spawns `orion_tr_key_cli.py` to:
+1. Pair using the GX passkey (from `orion_tr_pin.py`)
+2. PUK CRC authenticate on `97580006`
+3. Read VREG `0xEC65` (16-byte key)
+4. Read VREG `0x0140` (firmware), `0xEDDB` (temperature), `0x0100` (product id)
+
+The key is stored as a silent setting at:
+`/Settings/Devices/orion_tr_<mac12>/AdvertisementKey`
+
+If decryption later fails with `AdvertisementKeyMismatchError`, the
+driver clears the in-memory key and re-provisions (with 3-minute backoff).
+
+### Pairing PIN
+
+Resolution order (highest priority first):
+1. `/data/conf/dbus-ble-sensors-py-orion.ini` `[orion] PairingPin`
+2. `/Settings/Ble/Service/Pincode` (Cerbo Bluetooth PIN from gui-v2)
+3. Default `0` (passkey `000000`)
+
+### Daily refresh
+
+Between 3 AM and 5 AM local time, the first advertisement received from
+a provisioned Orion-TR triggers a GATT session that re-reads firmware
+and temperature.  Runs at most once per calendar day per device, only
+when the device is in range (sending advertisements).
+
+## Stock service conflict
+
+Venus OS ships `dbus-ble-sensors` (C binary) which claims the same
+`com.victronenergy.ble` bus name.  The start script
+(`start-dbus-ble-sensors-py.sh`) automatically stops it with
+`svc -d /service/dbus-ble-sensors` before launching.
+
+## Build / deployment
+
+### Development (scp)
+
+```bash
+scp src/opt/victronenergy/dbus-ble-sensors-py/*.py \
+    root@dev-cerbo:/opt/victronenergy/dbus-ble-sensors-py/
+scp -r src/opt/victronenergy/dbus-ble-sensors-py/ext/victron_ble \
+    root@dev-cerbo:/opt/victronenergy/dbus-ble-sensors-py/ext/
+ssh root@dev-cerbo svc -t /service/dbus-ble-sensors-py
+```
+
+### opkg build
+
+`requirements.sh` installs `victron-ble` from PyPI and patches it for
+`cryptography`.  The patch is a sed replacement of the `Crypto.Cipher`
+imports in `ext/victron_ble/devices/base.py`.
+
+### Python dependency
+
+`python3-cryptography` (opkg) — shipped in the stock Venus OS image.
+No PyCryptodome needed.

--- a/src/CONTROL/requirements.sh
+++ b/src/CONTROL/requirements.sh
@@ -10,3 +10,6 @@ wget -O "$SCRIPT_DIR/../opt/victronenergy/dbus-ble-sensors-py/ext/velib_python/v
 # Downloading packages
 export SKIP_CYTHON=false; pip3 install bleak --no-deps --target "$SCRIPT_DIR/../opt/victronenergy/dbus-ble-sensors-py/ext/"
 pip3 install gbulb --no-deps --target "$SCRIPT_DIR/../opt/victronenergy/dbus-ble-sensors-py/ext/"
+
+# victron_ble: used by the Orion-TR driver for encrypted advertisement decoding.
+pip3 install victron-ble --no-deps --target "$SCRIPT_DIR/../opt/victronenergy/dbus-ble-sensors-py/ext/"

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_orion_tr.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_device_orion_tr.py
@@ -1,0 +1,818 @@
+"""
+Victron Orion-TR Smart (BLE manufacturer ``0x02E1``, product IDs
+``0xA3C0``–``0xA3DF``).
+
+This device is **not** registered in ``BleDevice.DEVICE_CLASSES`` because
+``0x02E1`` is already owned by ``BleDeviceVictronEnergy`` (SolarSense).
+Dispatch is handled explicitly in :mod:`dbus_ble_sensors`.
+
+Compared to the other devices in this service, the Orion-TR has two
+unusual needs:
+
+1. **Encrypted advertisements.** The 16-byte advertisement key is
+   device-specific and is not printed on the unit.  It can only be read
+   from the device itself via a paired GATT session.  We store the key
+   in a *silent* setting under
+   ``/Settings/Services/BleSensors/OrionTr/<mac>/AdvertisementKey`` and
+   kick off :class:`orion_tr_key_provision.OrionKeyProvisioner` when
+   the setting is missing or stale.
+
+2. **``dcdc`` vs ``alternator`` service.** When the unit runs a charger
+   algorithm (bulk/absorption/float/storage) the stock Victron service
+   publishes under ``com.victronenergy.alternator.*`` so the gui-v2
+   *DC Sources* page picks it up.  When the unit is off or in
+   fixed-output mode the service type flips to
+   ``com.victronenergy.dcdc.*``.  This driver switches between the two
+   roles at runtime to stay in parity with ``dbus-victron-orion-tr``.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+import struct
+import subprocess
+import threading
+import time
+from typing import Any, Dict, Optional
+
+import dbus
+
+from ble_device import BleDevice
+from ble_role import BleRole
+from dbus_ble_service import DbusBleService
+from dbus_role_service import DbusRoleService
+from dbus_settings_service import DbusSettingsService
+# The vendored ``victron_ble`` package (see ``ext/victron_ble``) is the
+# reference decoder and matches the layout used by the upstream Victron
+# Energy tooling.  It has been patched to use ``cryptography`` instead of
+# PyCryptodome so it runs on the stock Venus OS image.
+from victron_ble.devices import detect_device_type  # type: ignore
+from victron_ble.exceptions import (  # type: ignore
+    AdvertisementKeyMismatchError,
+)
+
+from orion_tr_gatt import AsyncGATTWriter
+from orion_tr_key_settings import (
+    advertisement_key_setting_path,
+    get_advertisement_key,
+    get_firmware_version,
+    get_preferred_adapter,
+    set_advertisement_key,
+    set_firmware_version,
+    set_preferred_adapter,
+)
+from orion_tr_pin import resolve_pairing_passkey
+from scan_control import pause_scanning, resume_scanning
+from ve_types import VE_UN8
+
+logger = logging.getLogger(__name__)
+
+VICTRON_MANUFACTURER_ID = 0x02E1
+ORION_PRODUCT_ID_MIN = 0xA3C0
+ORION_PRODUCT_ID_MAX = 0xA3DF
+VREG_DEVICE_MODE = 0x0200
+
+# gui-v2 renders alternator units under "DC Sources" based on /ProductId:
+# a value >= 0xA3E0 is treated as "real alternator" and uses
+# PageAlternatorModel.  0xA3F0 matches what the standalone service uses
+# when flipping to alternator mode.
+ALTERNATOR_PRODUCT_ID = 0xA3F0
+
+# Fallback product names for Orion-TR product IDs not (yet) in the
+# vendored victron_ble MODEL_ID_MAPPING.  Sourced from the standalone
+# dbus-victron-orion-tr driver.
+_ORION_PRODUCT_NAMES = {
+    0xA3C0: "Orion-TR Smart 12/12-18A",
+    0xA3C1: "Orion-TR Smart 12/24-10A",
+    0xA3C2: "Orion-TR Smart 12/48-6A",
+    0xA3D0: "Orion-TR Smart 24/12-20A",
+    0xA3D1: "Orion-TR Smart 24/24-12A",
+    0xA3D2: "Orion-TR Smart 24/48-6A",
+    0xA3D5: "Orion-TR Smart 48/24-12A",
+    0xA3D6: "Orion-TR Smart 48/48-6A",
+}
+
+# VE.Direct OperationMode values that indicate charger-style operation.
+_CHARGER_MODES = {3, 4, 5, 6}  # BULK, ABSORPTION, FLOAT, STORAGE
+
+_gatt_writer: Optional[AsyncGATTWriter] = None
+
+# Single in-flight guard for the subprocess provisioner.  ``threading.Lock``
+# is enough — the provisioner thread simply blocks on ``_provision_lock``
+# while the subprocess runs, and ``_provision_busy`` tells the device
+# callback whether it should skip another attempt.
+_provision_lock = threading.Lock()
+_provision_busy = False
+
+# Absolute path to the CLI provisioner so we don't depend on PATH.
+_KEY_CLI_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "orion_tr_key_cli.py")
+
+
+def is_orion_tr_manufacturer_data(manufacturer_data: bytes) -> bool:
+    if len(manufacturer_data) < 4:
+        return False
+    pid = struct.unpack("<H", manufacturer_data[2:4])[0]
+    return ORION_PRODUCT_ID_MIN <= pid <= ORION_PRODUCT_ID_MAX
+
+
+def _shared_bus() -> dbus.Bus:
+    return (
+        dbus.SessionBus()
+        if "DBUS_SESSION_BUS_ADDRESS" in os.environ
+        else dbus.SystemBus()
+    )
+
+
+def _gatt() -> AsyncGATTWriter:
+    global _gatt_writer
+    if _gatt_writer is None:
+        _gatt_writer = AsyncGATTWriter(_shared_bus())
+    return _gatt_writer
+
+
+def _run_key_cli(mac: str, passkey: int,
+                 timeout_s: float = 45.0,
+                 preferred_adapter: Optional[str] = None,
+                 ) -> Optional[Dict[str, Any]]:
+    """Invoke :mod:`orion_tr_key_cli` and return its parsed JSON payload.
+
+    Running in a separate process keeps the provisioning flow isolated
+    from this service's long-lived D-Bus and BlueZ state, which was
+    observed to produce corrupt CCCD writes on the second and later
+    provisioning attempt within the same service lifetime.  The CLI
+    mirrors the known-good reference test harness verbatim.
+
+    Returns a dict with at least ``key`` (32-hex string) and optionally
+    ``firmware`` (raw hex bytes of VREG ``0x0140``), or ``None`` if the
+    subprocess failed.
+    """
+    cmd = [
+        "python3", _KEY_CLI_PATH,
+        mac,
+        "--passkey", str(passkey),
+        "--timeout", str(int(timeout_s)),
+    ]
+    if preferred_adapter:
+        cmd.extend(["--preferred-adapter", preferred_adapter])
+    logger.info("Spawning key-provisioner subprocess: %s", " ".join(cmd))
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s + 15.0,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("orion key-provisioner subprocess timed out for %s",
+                       mac)
+        return None
+    except Exception:
+        logger.exception("failed to spawn orion key-provisioner subprocess")
+        return None
+
+    if result.returncode != 0:
+        logger.warning("orion key-provisioner subprocess exited %d: %s",
+                       result.returncode, (result.stderr or "").strip())
+        return None
+
+    raw = (result.stdout or "").strip()
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        logger.warning("orion key-provisioner produced non-JSON output: %r",
+                       raw)
+        return None
+
+    key = str(payload.get("key", "")).strip().lower()
+    if len(key) != 32 or any(c not in "0123456789abcdef" for c in key):
+        logger.warning("orion key-provisioner returned invalid key: %r",
+                       key)
+        return None
+    payload["key"] = key
+    return payload
+
+
+def _format_firmware_version(raw_hex: Optional[str]) -> Optional[str]:
+    """Decode VREG ``0x0140`` bytes into a ``"major.minor"`` string.
+
+    Victron product-info firmware registers use hex-BCD encoding: each
+    nibble is a decimal digit, and the low 16 bits are the
+    ``MAJOR.MINOR`` version number.  On a 4-byte value the high byte
+    carries a release-type marker (``0x40`` = Release, ``0x50`` = Beta)
+    which we expose via a trailing ``~beta``/``~dev`` tag when present.
+
+    * 2 bytes LE ``48 01`` → value ``0x0148`` → ``"1.48"``
+    * 4 bytes LE ``10 01 00 40`` → low 16 bits ``0x0110`` → ``"1.10"``
+    * 4 bytes LE ``10 01 00 50`` → ``"1.10~beta"``
+
+    Falls back to the raw hex when the encoding doesn't match so at
+    least something shows in the UI.
+    """
+    if not raw_hex:
+        return None
+    try:
+        blob = bytes.fromhex(raw_hex)
+    except ValueError:
+        return None
+
+    def _bcd_byte(b: int) -> int:
+        return ((b >> 4) & 0xF) * 10 + (b & 0xF)
+
+    def _format_low16(value16: int) -> Optional[str]:
+        if value16 in (0, 0xFFFF):
+            return None
+        major = _bcd_byte((value16 >> 8) & 0xFF)
+        minor = _bcd_byte(value16 & 0xFF)
+        return f"{major}.{minor:02d}"
+
+    if len(blob) == 2:
+        v = int.from_bytes(blob, "little")
+        s = _format_low16(v)
+        if s:
+            return s
+    if len(blob) == 4:
+        v = int.from_bytes(blob, "little")
+        if v in (0, 0xFFFFFFFF):
+            return raw_hex
+        base = _format_low16(v & 0xFFFF)
+        if base is None:
+            return raw_hex
+        kind = (v >> 24) & 0xF0
+        suffix = {
+            0x40: "",      # Release
+            0x50: "~beta",
+            0xF0: "~dev",
+        }.get(kind, "")
+        return base + suffix
+    # Fallback: raw hex so the user can see *something*.
+    return raw_hex
+
+
+def _parse_temperature(raw_hex: Optional[str]) -> Optional[float]:
+    """Decode VREG ``0xEDDB`` (charger temperature) into degrees Celsius.
+
+    The register returns a signed 16-bit LE value in units of 0.01 °C.
+    (Observed values: ``0x0a14`` = 2580 → 25.8 °C — consistent with room
+    temperature.  The Orion-TR uses direct Celsius, not Kelvin.)
+    Returns ``None`` when the value is the invalid sentinel ``0x7FFF``.
+    """
+    if not raw_hex:
+        return None
+    try:
+        blob = bytes.fromhex(raw_hex)
+    except ValueError:
+        return None
+    if len(blob) < 2:
+        return None
+    raw = int.from_bytes(blob[:2], "little", signed=True)
+    if raw == 0x7FFF or raw == -1:
+        return None
+    return round(raw / 100.0, 1)
+
+
+def _format_mac_colons(dev_mac: str) -> str:
+    s = dev_mac.lower().replace(":", "")
+    return ":".join(s[i : i + 2] for i in range(0, 12, 2)).upper()
+
+
+def _bluez_device_name(dev_mac: str) -> Optional[str]:
+    """Return the BlueZ-reported advertised name for ``dev_mac``, if known.
+
+    Searches all adapters for the device (not just hci0) and reads
+    ``org.bluez.Device1.Name``.  Falls back to ``Device1.Alias`` if the
+    name is missing, and to ``None`` if BlueZ does not yet have a record.
+    """
+    mac_suffix = "/dev_" + _format_mac_colons(dev_mac).replace(":", "_")
+    try:
+        bus = _shared_bus()
+        om = dbus.Interface(
+            bus.get_object("org.bluez", "/", introspect=False),
+            "org.freedesktop.DBus.ObjectManager")
+        objects = om.GetManagedObjects()
+        for path in objects:
+            if not str(path).endswith(mac_suffix):
+                continue
+            if "org.bluez.Device1" not in objects[path]:
+                continue
+            obj = bus.get_object("org.bluez", path, introspect=False)
+            props = dbus.Interface(obj, "org.freedesktop.DBus.Properties")
+            for prop in ("Name", "Alias"):
+                try:
+                    val = str(props.Get("org.bluez.Device1", prop))
+                except dbus.DBusException:
+                    continue
+                if val:
+                    return val
+    except Exception:
+        return None
+    return None
+
+
+class BleDeviceOrionTR(BleDevice):
+    """Orion-TR Smart DC-DC / buck-boost on encrypted Victron manufacturer data."""
+
+    @staticmethod
+    def matches_manufacturer_data(manufacturer_data: bytes) -> bool:
+        return is_orion_tr_manufacturer_data(manufacturer_data)
+
+    def __init__(self, dev_mac: str):
+        self._adv_key_hex: Optional[str] = None
+        self._dbus_settings = DbusSettingsService()
+        self._pairing_passkey: int = resolve_pairing_passkey(self._dbus_settings)
+        self._mode_busy = False
+        # Monotonic timestamp of last provisioning kick-off, for backoff.
+        self._last_provision_attempt: float = 0.0
+        # When we see a KeyMismatch we stop trusting the stored key until a
+        # fresh provisioning round writes a new one.  Without this guard we
+        # would re-read the stale key from settings on every advertisement.
+        self._stored_key_invalid = False
+        # YYYY-MM-DD of the last successful daily refresh; drives the
+        # "once per morning when in range" GATT read.
+        self._last_daily_refresh_date: Optional[str] = None
+        self._current_role_name: Optional[str] = None
+        super().__init__(dev_mac)
+
+    # ------------------------------------------------------------------
+    # Device configuration
+    # ------------------------------------------------------------------
+
+    def configure(self, manufacturer_data: bytes):
+        pid = struct.unpack("<H", manufacturer_data[2:4])[0]
+        self._adv_key_hex = get_advertisement_key(self._dbus_settings,
+                                                  self.info["dev_mac"])
+        # Base ``_load_configuration`` re-reads ``self.MANUFACTURER_ID`` and
+        # overwrites ``info["manufacturer_id"]`` from it.  The class-level
+        # ``MANUFACTURER_ID`` is intentionally ``None`` (so the autoloader
+        # leaves 0x02E1 to ``BleDeviceVictronEnergy`` / SolarSense); shadow
+        # it via an instance attribute so the base validation still passes.
+        self.MANUFACTURER_ID = VICTRON_MANUFACTURER_ID
+        # Prefer the name the device actually advertises (e.g.
+        # ``"Orion Smart HQ20326VVVJ"``) over a hard-coded label so the
+        # gui-v2 Settings → Devices row matches what the user sees on
+        # their unit.  Falls back to ``Orion-TR Smart`` when BlueZ has
+        # not surfaced a name yet (e.g. first pass before bonding).
+        adv_name = _bluez_device_name(self.info["dev_mac"])
+        product_name = adv_name or "Orion-TR Smart"
+        device_name_base = adv_name or "Orion-TR"
+        # Firmware version: cached from a prior GATT read, falls back to
+        # the placeholder the base class expects if we haven't paired yet.
+        firmware_raw = get_firmware_version(self._dbus_settings,
+                                            self.info["dev_mac"])
+        firmware_version = _format_firmware_version(firmware_raw) or "1.0.0"
+        self.info.update(
+            {
+                "manufacturer_id": VICTRON_MANUFACTURER_ID,
+                "product_id": pid,
+                "product_name": product_name,
+                "device_name": device_name_base,
+                "dev_prefix": "orion_tr",
+                "firmware_version": firmware_version,
+                # Start in dcdc; flip happens after the first successful decode.
+                "roles": {"dcdc": {}},
+                "regs": [
+                    {
+                        "name": "_orion_placeholder",
+                        "type": VE_UN8,
+                        "offset": 0,
+                        "roles": [None],
+                    }
+                ],
+                "settings": [],
+                "alarms": [],
+            }
+        )
+        self._current_role_name = "dcdc"
+
+    def init(self):
+        super().init()
+        # Seed CustomName from the BLE-advertised name so the device
+        # list shows the user's own label (e.g. "24v Front Bay") instead
+        # of the long model spec.  Only set if the user hasn't already
+        # chosen a custom name via the UI.
+        adv_name = _bluez_device_name(self.info["dev_mac"])
+        if adv_name:
+            for role_service in self._role_services.values():
+                current = role_service["/CustomName"]
+                if not current:
+                    role_service["/CustomName"] = adv_name
+
+    def check_manufacturer_data(self, manufacturer_data: bytes) -> bool:
+        return self.matches_manufacturer_data(manufacturer_data)
+
+    # ------------------------------------------------------------------
+    # Main advertisement handler
+    # ------------------------------------------------------------------
+
+    def handle_manufacturer_data(self, manufacturer_data: bytes):
+        if not DbusBleService.get().is_device_enabled(self.info):
+            return
+
+        if self._stored_key_invalid:
+            # Waiting on a re-provision; avoid decoding with a known-bad key.
+            self._maybe_provision_key()
+            return
+
+        key = self._adv_key_hex or get_advertisement_key(
+            self._dbus_settings, self.info["dev_mac"])
+        if key:
+            self._adv_key_hex = key
+
+        if not key:
+            # First time we see this device — kick off provisioning once;
+            # subsequent advertisements will decode normally as soon as the
+            # key has been written to settings.
+            self._maybe_provision_key()
+            return
+
+        try:
+            parsed = self._decode_advertisement(key, manufacturer_data)
+        except AdvertisementKeyMismatchError:
+            logger.warning(
+                "%s: advertisement decrypt failed (key mismatch) — "
+                "re-reading VREG 0xEC65",
+                self._plog,
+            )
+            self._stored_key_invalid = True
+            self._adv_key_hex = None
+            self._maybe_provision_key()
+            return
+        except Exception:
+            logger.exception("%s: Orion advertisement decode error",
+                             self._plog)
+            return
+
+        if parsed is None:
+            return
+
+        self._ensure_role_for_state(int(parsed["device_state"]))
+        self._publish(parsed)
+
+        # Receiving an advertisement means the unit is in range right
+        # now — good moment to piggyback an opportunistic firmware refresh
+        # if we're in the morning window and haven't done it today.
+        self._maybe_daily_refresh()
+
+    @staticmethod
+    def _decode_advertisement(key_hex: str, manufacturer_data: bytes):
+        """Decrypt + parse a Victron DC-DC advertisement via ``victron_ble``.
+
+        Returns a small dict with the same shape the rest of the driver
+        expects so the callers can stay agnostic of the ``victron_ble``
+        ``DeviceData`` objects.
+        """
+        device_cls = detect_device_type(manufacturer_data)
+        if device_cls is None:
+            return None
+        parser = device_cls(key_hex)
+        parsed = parser.parse(manufacturer_data)
+
+        charge_state = parsed.get_charge_state()
+        charger_error = parsed.get_charger_error()
+        off_reason = parsed.get_off_reason()
+
+        # victron_ble's model-id table may not cover all Orion-TR product
+        # IDs (e.g. 0xA3D5 48V models).  Fall back to our own table.
+        model_name = parsed.get_model_name()
+        if model_name and model_name.startswith("<Unknown"):
+            pid = struct.unpack("<H", manufacturer_data[2:4])[0]
+            model_name = _ORION_PRODUCT_NAMES.get(pid, model_name)
+
+        return {
+            "device_state": int(charge_state.value) if charge_state is not None else 0,
+            "charger_error": int(charger_error.value) if charger_error is not None else 0,
+            "input_voltage": parsed.get_input_voltage(),
+            "output_voltage": parsed.get_output_voltage(),
+            "off_reason": int(off_reason.value) if off_reason is not None else 0,
+            "model_name": model_name,
+        }
+
+    # ------------------------------------------------------------------
+    # Key provisioning lifecycle
+    # ------------------------------------------------------------------
+
+    # Minimum time between provisioning attempts when the previous one
+    # did not deliver a key.  Pairing + GATT + timeout can run ~45 s so a
+    # tight loop would lock out the adapter.
+    _PROVISION_BACKOFF_SECS = 180.0
+
+    def _maybe_provision_key(self) -> None:
+        global _provision_busy
+        if _provision_busy:
+            return
+        now = time.monotonic()
+        since_last = now - self._last_provision_attempt
+        if (self._last_provision_attempt > 0
+                and since_last < self._PROVISION_BACKOFF_SECS):
+            return
+
+        self._last_provision_attempt = now
+        mac_colon = _format_mac_colons(self.info["dev_mac"])
+        logger.info(
+            "%s: no advertisement key cached — spawning subprocess to "
+            "read VREG 0xEC65",
+            self._plog,
+        )
+
+        # Yield hci0 to the provisioner subprocess so BleakScanner and
+        # the mode-write path don't step on its GATT burst.  Released in
+        # the worker thread regardless of outcome.
+        pause_scanning("orion-tr key provisioning")
+        _provision_busy = True
+
+        # Check if we have a preferred adapter from a prior successful connect
+        pref_adapter = get_preferred_adapter(self._dbus_settings,
+                                             self.info["dev_mac"])
+
+        def worker():
+            global _provision_busy
+            try:
+                with _provision_lock:
+                    payload = _run_key_cli(mac_colon,
+                                           self._pairing_passkey,
+                                           preferred_adapter=pref_adapter)
+                if not payload:
+                    logger.warning(
+                        "%s: key provisioning did not produce a 16-byte "
+                        "key; will retry after backoff",
+                        self._plog)
+                    return
+                self._persist_provisioning_result(payload)
+            finally:
+                _provision_busy = False
+                resume_scanning("orion-tr key provisioning")
+
+        threading.Thread(
+            target=worker, name=f"orion-tr-keyprov-{mac_colon}",
+            daemon=True).start()
+
+    def _persist_provisioning_result(self, payload: Dict[str, Any]) -> None:
+        """Write key + firmware from a CLI payload into settings + info."""
+        key_hex = payload.get("key")
+        if key_hex:
+            try:
+                set_advertisement_key(self._dbus_settings,
+                                      self.info["dev_mac"], key_hex)
+                self._adv_key_hex = key_hex
+                self._stored_key_invalid = False
+                logger.info(
+                    "%s: advertisement key stored at %s",
+                    self._plog,
+                    advertisement_key_setting_path(
+                        self.info["dev_mac"]))
+            except Exception:
+                logger.exception(
+                    "%s: failed to persist advertisement key", self._plog)
+
+        firmware_raw = payload.get("firmware")
+        if firmware_raw:
+            try:
+                set_firmware_version(self._dbus_settings,
+                                     self.info["dev_mac"], firmware_raw)
+                pretty = _format_firmware_version(firmware_raw) or firmware_raw
+                self.info["firmware_version"] = pretty
+                for role_service in self._role_services.values():
+                    try:
+                        role_service["/FirmwareVersion"] = pretty
+                    except Exception:
+                        pass
+                logger.info("%s: firmware version %s recorded",
+                            self._plog, pretty)
+            except Exception:
+                logger.exception(
+                    "%s: failed to persist firmware version", self._plog)
+
+        hw_version = payload.get("hardware_version")
+        if hw_version:
+            try:
+                self.info["hardware_version"] = hw_version
+                for role_service in self._role_services.values():
+                    try:
+                        role_service["/HardwareVersion"] = hw_version
+                    except Exception:
+                        pass
+                logger.info("%s: hardware version %s recorded",
+                            self._plog, hw_version)
+            except Exception:
+                logger.exception(
+                    "%s: failed to set hardware version", self._plog)
+
+        temperature_raw = payload.get("temperature")
+        if temperature_raw:
+            try:
+                temp_c = _parse_temperature(temperature_raw)
+                if temp_c is not None:
+                    for role_service in self._role_services.values():
+                        try:
+                            role_service["/Dc/0/Temperature"] = temp_c
+                        except Exception:
+                            pass
+                    logger.info("%s: temperature %.1f °C recorded",
+                                self._plog, temp_c)
+            except Exception:
+                logger.exception(
+                    "%s: failed to parse temperature", self._plog)
+
+        adapter = payload.get("adapter")
+        if adapter:
+            try:
+                set_preferred_adapter(self._dbus_settings,
+                                     self.info["dev_mac"], adapter)
+            except Exception:
+                logger.exception(
+                    "%s: failed to store preferred adapter", self._plog)
+
+    # ------------------------------------------------------------------
+    # Daily early-morning refresh
+    # ------------------------------------------------------------------
+
+    # Hour window (local time, 24h) during which we allow an opportunistic
+    # pair-and-refresh.  The device must send an advertisement first — we
+    # only act if it's in range, and at most once per calendar day.
+    _DAILY_REFRESH_HOUR_MIN = 3
+    _DAILY_REFRESH_HOUR_MAX = 5
+
+    def _maybe_daily_refresh(self) -> None:
+        global _provision_busy
+        # Only if we already have a valid stored key — we never kick off
+        # a daily refresh on a device we haven't successfully provisioned
+        # yet; that path is handled by the key-missing logic above.
+        if not self._adv_key_hex:
+            return
+        if _provision_busy:
+            return
+        now = datetime.datetime.now()
+        if not (self._DAILY_REFRESH_HOUR_MIN <= now.hour
+                <= self._DAILY_REFRESH_HOUR_MAX):
+            return
+        today = now.strftime("%Y-%m-%d")
+        if self._last_daily_refresh_date == today:
+            return
+
+        # Mark attempted *before* kicking off so a repeating advert burst
+        # during the window doesn't queue multiple refreshes.
+        self._last_daily_refresh_date = today
+        mac_colon = _format_mac_colons(self.info["dev_mac"])
+        logger.info(
+            "%s: daily morning refresh — reading firmware via GATT",
+            self._plog)
+
+        pref_adapter = get_preferred_adapter(self._dbus_settings,
+                                             self.info["dev_mac"])
+        pause_scanning("orion-tr daily refresh")
+        _provision_busy = True
+
+        def worker():
+            global _provision_busy
+            try:
+                with _provision_lock:
+                    payload = _run_key_cli(mac_colon,
+                                           self._pairing_passkey,
+                                           preferred_adapter=pref_adapter)
+                if not payload:
+                    logger.warning(
+                        "%s: daily refresh did not produce a payload",
+                        self._plog)
+                    # Don't clobber _last_daily_refresh_date — we already
+                    # set it; the next retry will be tomorrow.  If that's
+                    # too strict we can wire a backoff here later.
+                    return
+                self._persist_provisioning_result(payload)
+            finally:
+                _provision_busy = False
+                resume_scanning("orion-tr daily refresh")
+
+        threading.Thread(
+            target=worker, name=f"orion-tr-daily-{mac_colon}",
+            daemon=True).start()
+
+    # ------------------------------------------------------------------
+    # Publishing decoded values
+    # ------------------------------------------------------------------
+
+    def _publish(self, parsed) -> None:
+        for role_service in list(self._role_services.values()):
+            ble_svc = DbusBleService.get()
+            if not ble_svc.is_device_role_enabled(
+                    self.info, role_service.ble_role.NAME):
+                continue
+
+            st = int(parsed["device_state"])
+            if parsed.get("input_voltage") is not None:
+                role_service["/Dc/In/V"] = parsed["input_voltage"]
+            if parsed.get("output_voltage") is not None:
+                role_service["/Dc/0/Voltage"] = parsed["output_voltage"]
+
+            # ProductName = model spec from victron_ble's product-id table.
+            model = parsed.get("model_name")
+            if model and not model.startswith("<Unknown"):
+                role_service["/ProductName"] = model
+            role_service["/State"] = st
+            role_service["/ErrorCode"] = int(parsed["charger_error"])
+            role_service["/DeviceOffReason"] = int(parsed["off_reason"])
+
+            # Keep /Mode in sync with the inferred mode, unless a write is
+            # pending against the device.
+            if not self._mode_busy:
+                role_service["/Mode"] = 4 if st == 0 else 1
+
+            # Force /ProductId to match the active service type.  gui-v2
+            # keys its layout off /ProductId for alternator services.
+            if role_service.ble_role.NAME == "alternator":
+                role_service["/ProductId"] = ALTERNATOR_PRODUCT_ID
+            else:
+                role_service["/ProductId"] = self.info["product_id"]
+
+            role_service.connect()
+
+    # ------------------------------------------------------------------
+    # dcdc ↔ alternator flip
+    # ------------------------------------------------------------------
+
+    def _ensure_role_for_state(self, device_state: int) -> None:
+        needed = "alternator" if device_state in _CHARGER_MODES else "dcdc"
+        if needed == self._current_role_name:
+            return
+        logger.info("%s: device state %d — switching role from %r to %r",
+                    self._plog, device_state,
+                    self._current_role_name, needed)
+        self._swap_role(needed)
+
+    def _swap_role(self, new_role_name: str) -> None:
+        # Tear down every existing role.  There should only be one at a
+        # time for an Orion-TR, but be defensive.
+        for name, role_service in list(self._role_services.items()):
+            try:
+                role_service.disconnect()
+            except Exception:
+                logger.exception("%s: disconnect failed for role %r",
+                                 self._plog, name)
+            try:
+                DbusBleService.get().unregister_role_service(role_service)
+            except Exception:
+                logger.exception("%s: unregister failed for role %r",
+                                 self._plog, name)
+        self._role_services.clear()
+
+        # Register the new role
+        role_cls = BleRole.get_class(new_role_name)
+        if role_cls is None:
+            logger.error("%s: role %r not registered — keeping previous",
+                         self._plog, new_role_name)
+            return
+        role = role_cls({})
+        try:
+            role.check_configuration()
+        except ValueError:
+            logger.exception("%s: role %r configuration invalid",
+                             self._plog, new_role_name)
+            return
+        role_service = DbusRoleService(self, role)
+        role_service.load_settings()
+        self._role_services[new_role_name] = role_service
+        DbusBleService.get().register_role_service(role_service)
+        self._current_role_name = new_role_name
+        self.info["roles"] = {new_role_name: {}}
+
+    # ------------------------------------------------------------------
+    # Mode write (GATT)
+    # ------------------------------------------------------------------
+
+    def _orion_on_mode_write(self,
+                             role_service: DbusRoleService,
+                             value: int) -> bool:
+        if value not in (1, 4):
+            return False
+        writer = _gatt()
+        if writer.busy:
+            logger.warning("%s: GATT writer busy", self._plog)
+            return False
+
+        self._mode_busy = True
+        mac = _format_mac_colons(self.info["dev_mac"])
+        mode_byte = 4 if value == 4 else 1
+
+        # The mode-write path pairs, connects, writes VREG 0x0200 and
+        # disconnects.  Like the key-provisioner it needs the adapter to
+        # itself, so pause the scan loop for the duration.
+        pause_scanning("orion-tr /Mode write")
+
+        def on_done(success: bool):
+            try:
+                self._mode_busy = False
+                if not success:
+                    logger.error("%s: GATT mode write failed", self._plog)
+            finally:
+                resume_scanning("orion-tr /Mode write")
+
+        writer.write_register(
+            mac,
+            self._pairing_passkey,
+            VREG_DEVICE_MODE,
+            bytes([mode_byte]),
+            on_done=on_done,
+        )
+        return True

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_alternator.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_alternator.py
@@ -1,0 +1,51 @@
+"""
+Alternator role (Venus OS ``alternator`` service type).
+
+Used for Victron Orion-TR Smart devices when they are operating in a
+charger algorithm (bulk / absorption / float / storage).  In that state
+the stock ``dbus-victron-orion-tr`` service publishes under
+``com.victronenergy.alternator.*`` so the unit appears on the
+*DC Sources* page (see ``gui-v2/pages/settings/devicelist/dc-in/
+PageAlternator.qml``).  This mirrors that behaviour inside
+``dbus-ble-sensors-py``.
+
+When the device is off or running in fixed-output (PSU) mode it should
+instead be published as a ``dcdc`` service — see :mod:`ble_role_dcdc`.
+The parent device (``BleDeviceOrionTR``) is responsible for swapping
+the role in response to state changes.
+"""
+from ble_role import BleRole
+
+
+class BleRoleAlternator(BleRole):
+    NAME = "alternator"
+
+    def __init__(self, config: dict = None):
+        super().__init__()
+        self.info.update(
+            {
+                "name": "alternator",
+                "dev_instance": 130,
+                "settings": [],
+                "alarms": [],
+            }
+        )
+
+    def init(self, role_service):
+        svc = role_service._dbus_service
+        with svc as s:
+            s.add_path("/Dc/In/V", None)
+            s.add_path("/Dc/In/I", None)
+            s.add_path("/Dc/In/P", None)
+            s.add_path("/Dc/0/Voltage", None)
+            s.add_path("/Dc/0/Current", None)
+            s.add_path("/Dc/0/Power", None)
+            s.add_path("/Dc/0/Temperature", None)
+            s.add_path("/State", 0)
+            s.add_path("/ErrorCode", 0)
+            s.add_path("/DeviceOffReason", 0)
+
+            def on_mode(path, value):
+                return role_service._ble_device._orion_on_mode_write(role_service, int(value))
+
+            s.add_path("/Mode", 1, writeable=True, onchangecallback=on_mode)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_dcdc.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/ble_role_dcdc.py
@@ -1,0 +1,43 @@
+from ble_role import BleRole
+from ve_types import *
+
+
+class BleRoleDcdc(BleRole):
+    """
+    DC-DC converter role (Venus OS ``dcdc`` service type).
+
+    Used for Victron Orion-TR Smart devices so they appear under the standard
+    DC-DC device page in gui-v2 (``PageDcDcConverter.qml``).
+    """
+
+    NAME = "dcdc"
+
+    def __init__(self, config: dict = None):
+        super().__init__()
+        self.info.update(
+            {
+                "name": "dcdc",
+                "dev_instance": 130,
+                "settings": [],
+                "alarms": [],
+            }
+        )
+
+    def init(self, role_service):
+        svc = role_service._dbus_service
+        with svc as s:
+            s.add_path("/Dc/In/V", None)
+            s.add_path("/Dc/In/I", None)
+            s.add_path("/Dc/In/P", None)
+            s.add_path("/Dc/0/Voltage", None)
+            s.add_path("/Dc/0/Current", None)
+            s.add_path("/Dc/0/Power", None)
+            s.add_path("/Dc/0/Temperature", None)
+            s.add_path("/State", 0)
+            s.add_path("/ErrorCode", 0)
+            s.add_path("/DeviceOffReason", 0)
+
+            def on_mode(path, value):
+                return role_service._ble_device._orion_on_mode_write(role_service, int(value))
+
+            s.add_path("/Mode", 1, writeable=True, onchangecallback=on_mode)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/conf.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/conf.py
@@ -11,3 +11,6 @@ DEVICE_SERVICES_TIMEOUT = 1800  # 30 min
 SCAN_TIMEOUT = 15
 SCAN_INTERVAL_STANDARD = 20  # 90
 SCAN_SLEEP = max(0, SCAN_INTERVAL_STANDARD - SCAN_TIMEOUT)
+
+# Optional ``[orion] PairingPin=…`` override for Orion-TR BLE pairing (see ``orion_tr_pin.py``).
+ORION_OPTIONAL_INI = "/data/conf/dbus-ble-sensors-py-orion.ini"

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_ble_sensors.py
@@ -10,8 +10,10 @@ import dbus
 from dbus.mainloop.glib import DBusGMainLoop
 from argparse import ArgumentParser
 from ble_device import BleDevice
+from ble_device_orion_tr import BleDeviceOrionTR, is_orion_tr_manufacturer_data
 from ble_role import BleRole
 from dbus_ble_service import DbusBleService
+from scan_control import is_scanning_paused
 import bleak
 import gbulb
 from logger import setup_logging
@@ -119,8 +121,15 @@ class DbusBleSensors(object):
                     # Snif new device advertising data
                     self.snif_data(man_id, man_data)
 
-                    # Get device class from manufacturer id
-                    device_class = BleDevice.DEVICE_CLASSES.get(man_id, None)
+                    # Get device class from manufacturer id.
+                    # Victron manufacturer id 0x02E1 is shared between multiple product families
+                    # (e.g. Orion-TR Smart non-isolated vs encrypted-advertisement devices);
+                    # route Orion-TR advertisements (product ids 0xA3C0..0xA3DF) to the
+                    # dedicated class before falling back to DEVICE_CLASSES.
+                    if man_id == 0x02E1 and is_orion_tr_manufacturer_data(man_data):
+                        device_class = BleDeviceOrionTR
+                    else:
+                        device_class = BleDevice.DEVICE_CLASSES.get(man_id, None)
                     if device_class is None:
                         logging.info(f"{plog} ignoring data {man_data!r}, no device configuration class for manufacturer {man_id!r}")
                         self._ignored_mac[dev_mac] = True
@@ -162,6 +171,12 @@ class DbusBleSensors(object):
             if len(self._adapters) < 1:
                 logging.warning("Waiting for a bluetooth adapter...")
                 await asyncio.sleep(5)
+                continue
+            # Drivers needing exclusive GATT access (e.g. Orion-TR key
+            # provisioning and daily refresh) can pause scanning via
+            # scan_control.pause_scanning(); idle until they release it.
+            if is_scanning_paused():
+                await asyncio.sleep(1)
                 continue
             scan_tasks = [asyncio.create_task(self._scan(adapter)) for adapter in self._adapters]
             await asyncio.gather(*scan_tasks)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_settings_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_settings_service.py
@@ -38,6 +38,13 @@ class DbusSettingsService(object):
     def get_value(self, path) -> object:  # int, float, str, None
         return self.get_item(path).get_value()
 
+    def try_get_value(self, path: str):
+        """Return setting value, or None if the path does not exist."""
+        item = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, path, createsignal=False)
+        if not item.exists:
+            return None
+        return item.get_value()
+
     def set_item(self, path: str, def_value: object = None, min_value: int = 0, max_value: int = 0, silent=False, callback=None) -> VeDbusItemImport:
         busitem = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, path, callback)
         if not busitem.exists or (def_value, min_value, max_value, silent) != busitem._proxy.GetAttributes():

--- a/src/opt/victronenergy/dbus-ble-sensors-py/orion_tr_gatt.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/orion_tr_gatt.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""
+BLE GATT Connection Manager for Victron Orion-TR Smart
+
+Async GATT write operations for on/off control. Uses the shared D-Bus
+SystemBus with async (reply_handler/error_handler) calls so the GLib
+main loop is never blocked.
+
+Protocol:
+- Service UUID: 306b0001-b081-4037-83dc-e59fcc3cdfd0
+- Control char (306b0002): Flow control
+- Data last-chunk char (306b0003): Register read/write
+"""
+
+import logging
+import struct
+import time
+from typing import Callable, Dict, Optional, Tuple
+
+import dbus
+import dbus.service
+import dbus.mainloop.glib
+from gi.repository import GLib
+
+logger = logging.getLogger(__name__)
+
+SERVICE_UUID = "306b0001-b081-4037-83dc-e59fcc3cdfd0"
+CHAR_CONTROL = "306b0002-b081-4037-83dc-e59fcc3cdfd0"
+CHAR_DATA_LAST = "306b0003-b081-4037-83dc-e59fcc3cdfd0"
+
+OPCODE_CHUNK_SIZE = 0xFA
+OPCODE_READY_TO_RECV = 0xF9
+
+AGENT_INTERFACE = "org.bluez.Agent1"
+
+
+def _cbor_uint(n: int) -> bytes:
+    if n < 24:
+        return bytes([n])
+    elif n < 256:
+        return bytes([0x18, n])
+    elif n < 65536:
+        return bytes([0x19, (n >> 8) & 0xFF, n & 0xFF])
+    return bytes([0x1A, (n >> 24) & 0xFF, (n >> 16) & 0xFF,
+                  (n >> 8) & 0xFF, n & 0xFF])
+
+
+def _cbor_array(items: list) -> bytes:
+    return bytes([0x9F]) + b"".join(items) + bytes([0xFF])
+
+
+def _cbor_bstr(data: bytes) -> bytes:
+    n = len(data)
+    if n < 24:
+        return bytes([0x40 | n]) + data
+    return bytes([0x58, n]) + data
+
+
+class _PairingAgent(dbus.service.Object):
+    """BlueZ D-Bus pairing agent that provides the Victron default passkey."""
+
+    def __init__(self, bus, path, passkey):
+        super().__init__(bus, path)
+        self._passkey = passkey
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="", out_signature="")
+    def Release(self):
+        pass
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="os", out_signature="")
+    def AuthorizeService(self, device, uuid):
+        pass
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="o", out_signature="u")
+    def RequestPasskey(self, device):
+        logger.info("Pairing agent: providing passkey")
+        return dbus.UInt32(self._passkey)
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="ou", out_signature="")
+    def RequestConfirmation(self, device, passkey):
+        pass
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="o", out_signature="")
+    def RequestAuthorization(self, device):
+        pass
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="", out_signature="")
+    def Cancel(self):
+        pass
+
+
+def _find_bluez_device(bus, mac):
+    """Find (device_path, adapter_path) for *mac* across all BlueZ adapters."""
+    om = dbus.Interface(
+        bus.get_object("org.bluez", "/", introspect=False),
+        "org.freedesktop.DBus.ObjectManager")
+    objects = om.GetManagedObjects()
+    suffix = "/dev_" + mac.upper().replace(":", "_")
+    for path in sorted(objects.keys()):
+        if str(path).endswith(suffix) and "org.bluez.Device1" in objects[path]:
+            s = str(path)
+            adapter_path = s[:s.index(suffix)]
+            return s, adapter_path
+    return "/org/bluez/hci0" + suffix, "/org/bluez/hci0"
+
+
+class AsyncGATTWriter:
+    """
+    Non-blocking GATT register writer.
+
+    Uses async D-Bus calls so it never blocks the GLib main loop.
+    Each step chains to the next via reply/error handlers.
+    """
+
+    def __init__(self, bus: dbus.SystemBus):
+        self._bus = bus
+        self._agent = None
+        self._busy = False
+
+    @property
+    def busy(self) -> bool:
+        return self._busy
+
+    def write_register(self, mac: str, passkey: int, register_id: int,
+                       value_bytes: bytes,
+                       on_done: Optional[Callable] = None):
+        """
+        Start an async register write.
+
+        Stops BLE scanning first to avoid BlueZ conflicts on the Cerbo,
+        then performs the GATT write, then restarts scanning.
+
+        Args:
+            mac: Device MAC (e.g. "EF:C1:11:9D:A3:91")
+            passkey: BLE pairing passkey
+            register_id: VREG register ID
+            value_bytes: Value bytes (little-endian)
+            on_done: Callback(success: bool) called when complete
+        """
+        if self._busy:
+            logger.warning("GATT writer busy, rejecting write for %s", mac)
+            if on_done:
+                on_done(False)
+            return
+
+        mac = mac.upper()
+        self._busy = True
+
+        device_path, adapter_path = _find_bluez_device(self._bus, mac)
+        ctx = {
+            "mac": mac,
+            "passkey": passkey,
+            "register_id": register_id,
+            "value_bytes": value_bytes,
+            "on_done": on_done,
+            "device_path": device_path,
+            "adapter_path": adapter_path,
+            "agent_path": "/oriontr/agent/%s" % mac.replace(":", ""),
+        }
+
+        logger.info("GATT write starting for %s: reg=0x%04X val=%s",
+                     mac, register_id, value_bytes.hex())
+
+        # Step 0: Stop BLE scanning to free the adapter
+        self._step_stop_adapter_scan(ctx)
+
+    def _step_stop_adapter_scan(self, ctx):
+        """Step 0: Stop BLE scanning before GATT operations."""
+        try:
+            adapter = dbus.Interface(
+                self._bus.get_object("org.bluez", ctx["adapter_path"],
+                                      introspect=False),
+                "org.bluez.Adapter1")
+
+            def on_stopped():
+                logger.info("BLE scanning paused for GATT write")
+                GLib.timeout_add(1000,
+                                 lambda: self._step_check_paired(ctx))
+
+            def on_stop_err(e):
+                logger.debug("StopDiscovery: %s (may not be scanning)", e)
+                GLib.timeout_add(500,
+                                 lambda: self._step_check_paired(ctx))
+
+            adapter.StopDiscovery(reply_handler=on_stopped,
+                                  error_handler=on_stop_err)
+        except Exception as e:
+            logger.debug("Stop scan: %s", e)
+            self._step_check_paired(ctx)
+
+    def _done(self, ctx, success: bool):
+        # Clean up agent
+        if self._agent:
+            try:
+                agent_mgr = dbus.Interface(
+                    self._bus.get_object("org.bluez", "/org/bluez",
+                                         introspect=False),
+                    "org.bluez.AgentManager1")
+                agent_mgr.UnregisterAgent(dbus.ObjectPath(ctx["agent_path"]))
+            except Exception:
+                pass
+            self._agent = None
+
+        # The main BleakScanner loop owns adapter discovery — just drop
+        # the pause reference via ``on_done`` and let it restart scanning
+        # on its next iteration.
+        self._busy = False
+        if ctx.get("on_done"):
+            ctx["on_done"](success)
+
+    def _step_check_paired(self, ctx):
+        """Step 1: Check if device is paired."""
+        try:
+            device_obj = self._bus.get_object(
+                "org.bluez", ctx["device_path"], introspect=False)
+            props = dbus.Interface(device_obj,
+                                   "org.freedesktop.DBus.Properties")
+
+            def on_paired(value):
+                if bool(value):
+                    logger.debug("Device %s already paired", ctx["mac"])
+                    self._step_connect(ctx)
+                else:
+                    self._step_pair(ctx)
+
+            def on_error(e):
+                logger.warning("Paired check failed for %s: %s",
+                               ctx["mac"], e)
+                # Device might not exist in BlueZ yet
+                self._step_scan(ctx)
+
+            props.Get("org.bluez.Device1", "Paired",
+                      reply_handler=on_paired,
+                      error_handler=on_error)
+
+        except Exception as e:
+            logger.info("Device %s not in BlueZ, scanning: %s",
+                         ctx["mac"], e)
+            self._step_scan(ctx)
+
+    def _step_scan(self, ctx):
+        """Step 1b: Scan for device."""
+        try:
+            adapter = dbus.Interface(
+                self._bus.get_object("org.bluez", ctx["adapter_path"],
+                                      introspect=False),
+                "org.bluez.Adapter1")
+
+            def on_start():
+                logger.debug("Scan started, waiting 5s...")
+                GLib.timeout_add(5000, lambda: self._step_stop_scan(ctx))
+
+            def on_start_err(e):
+                logger.warning("StartDiscovery failed: %s", e)
+                self._done(ctx, False)
+
+            adapter.StartDiscovery(reply_handler=on_start,
+                                   error_handler=on_start_err)
+        except Exception as e:
+            logger.error("Scan init failed: %s", e)
+            self._done(ctx, False)
+
+    def _step_stop_scan(self, ctx):
+        """Step 1c: Stop scan and check device."""
+        try:
+            adapter = dbus.Interface(
+                self._bus.get_object("org.bluez", ctx["adapter_path"],
+                                      introspect=False),
+                "org.bluez.Adapter1")
+            adapter.StopDiscovery(
+                reply_handler=lambda: None,
+                error_handler=lambda e: None)
+        except Exception:
+            pass
+
+        try:
+            self._bus.get_object("org.bluez", ctx["device_path"],
+                                  introspect=False)
+            self._step_check_paired(ctx)
+        except Exception:
+            logger.error("Device %s not found after scan", ctx["mac"])
+            self._done(ctx, False)
+        return False
+
+    def _step_pair(self, ctx):
+        """Step 2: Pair with device."""
+        logger.info("Pairing with %s (passkey %06d)...",
+                     ctx["mac"], ctx["passkey"])
+
+        # Register pairing agent
+        try:
+            self._agent = _PairingAgent(
+                self._bus, ctx["agent_path"], ctx["passkey"])
+        except KeyError:
+            pass
+
+        try:
+            agent_mgr = dbus.Interface(
+                self._bus.get_object("org.bluez", "/org/bluez",
+                                      introspect=False),
+                "org.bluez.AgentManager1")
+            agent_path = dbus.ObjectPath(ctx["agent_path"])
+            try:
+                agent_mgr.UnregisterAgent(agent_path)
+            except Exception:
+                pass
+            agent_mgr.RegisterAgent(agent_path, "KeyboardDisplay")
+            agent_mgr.RequestDefaultAgent(agent_path)
+        except Exception as e:
+            logger.warning("Agent registration: %s", e)
+
+        device_obj = self._bus.get_object(
+            "org.bluez", ctx["device_path"], introspect=False)
+
+        # Trust the device
+        props = dbus.Interface(device_obj,
+                               "org.freedesktop.DBus.Properties")
+        try:
+            props.Set("org.bluez.Device1", "Trusted", dbus.Boolean(True))
+        except Exception:
+            pass
+
+        # Connect first, then pair
+        device = dbus.Interface(device_obj, "org.bluez.Device1")
+
+        def on_connect():
+            GLib.timeout_add(2000, lambda: self._do_pair(ctx))
+
+        def on_connect_err(e):
+            logger.warning("Pre-pair connect: %s", e)
+            GLib.timeout_add(1000, lambda: self._do_pair(ctx))
+
+        device.Connect(reply_handler=on_connect,
+                       error_handler=on_connect_err)
+
+    def _do_pair(self, ctx):
+        device_obj = self._bus.get_object(
+            "org.bluez", ctx["device_path"], introspect=False)
+        device = dbus.Interface(device_obj, "org.bluez.Device1")
+
+        def on_pair():
+            logger.info("Paired with %s", ctx["mac"])
+            GLib.timeout_add(1000, lambda: self._step_connect(ctx))
+
+        def on_pair_err(e):
+            logger.error("Pair failed: %s", e)
+            # Check if it actually paired despite the error
+            try:
+                props = dbus.Interface(device_obj,
+                                       "org.freedesktop.DBus.Properties")
+                if bool(props.Get("org.bluez.Device1", "Paired")):
+                    logger.info("Paired despite error for %s", ctx["mac"])
+                    self._step_connect(ctx)
+                    return
+            except Exception:
+                pass
+            self._done(ctx, False)
+
+        device.Pair(reply_handler=on_pair,
+                    error_handler=on_pair_err)
+        return False
+
+    def _step_connect(self, ctx):
+        """Step 3: Connect to device."""
+        device_obj = self._bus.get_object(
+            "org.bluez", ctx["device_path"], introspect=False)
+        props = dbus.Interface(device_obj,
+                               "org.freedesktop.DBus.Properties")
+
+        def check_connected(connected):
+            if bool(connected):
+                logger.debug("Already connected to %s", ctx["mac"])
+                self._step_wait_services(ctx, 0)
+            else:
+                logger.info("Connecting to %s...", ctx["mac"])
+                device = dbus.Interface(device_obj, "org.bluez.Device1")
+
+                def on_connect():
+                    logger.info("Connected to %s", ctx["mac"])
+                    GLib.timeout_add(1000,
+                                     lambda: self._step_wait_services(ctx, 0))
+
+                def on_connect_err(e):
+                    logger.error("Connect to %s failed: %s", ctx["mac"], e)
+                    self._done(ctx, False)
+
+                device.Connect(reply_handler=on_connect,
+                               error_handler=on_connect_err)
+
+        def check_err(e):
+            logger.error("Connected check failed: %s", e)
+            self._done(ctx, False)
+
+        props.Get("org.bluez.Device1", "Connected",
+                  reply_handler=check_connected,
+                  error_handler=check_err)
+
+    def _step_wait_services(self, ctx, attempt):
+        """Step 4: Wait for ServicesResolved."""
+        if attempt >= 15:
+            logger.error("Services never resolved for %s", ctx["mac"])
+            self._done(ctx, False)
+            return False
+
+        device_obj = self._bus.get_object(
+            "org.bluez", ctx["device_path"], introspect=False)
+        props = dbus.Interface(device_obj,
+                               "org.freedesktop.DBus.Properties")
+
+        def on_resolved(value):
+            if bool(value):
+                self._step_discover_chars(ctx)
+            else:
+                GLib.timeout_add(
+                    1000,
+                    lambda: self._step_wait_services(ctx, attempt + 1))
+
+        def on_err(e):
+            GLib.timeout_add(
+                1000,
+                lambda: self._step_wait_services(ctx, attempt + 1))
+
+        props.Get("org.bluez.Device1", "ServicesResolved",
+                  reply_handler=on_resolved,
+                  error_handler=on_err)
+        return False
+
+    def _step_discover_chars(self, ctx):
+        """Step 5: Discover 306b characteristics."""
+        om = dbus.Interface(
+            self._bus.get_object("org.bluez", "/", introspect=False),
+            "org.freedesktop.DBus.ObjectManager")
+
+        def on_objects(objects):
+            char_paths: Dict[str, str] = {}
+            for path, interfaces in objects.items():
+                if "org.bluez.GattCharacteristic1" not in interfaces:
+                    continue
+                if not path.startswith(ctx["device_path"]):
+                    continue
+                cp = interfaces["org.bluez.GattCharacteristic1"]
+                char_uuid = str(cp.get("UUID", ""))
+                svc_path = str(cp.get("Service", ""))
+                if svc_path not in objects:
+                    continue
+                svc_ifs = objects[svc_path]
+                if "org.bluez.GattService1" not in svc_ifs:
+                    continue
+                svc_uuid = str(
+                    svc_ifs["org.bluez.GattService1"].get("UUID", ""))
+                if svc_uuid == SERVICE_UUID:
+                    char_paths[char_uuid] = path
+
+            if CHAR_DATA_LAST not in char_paths \
+                    or CHAR_CONTROL not in char_paths:
+                logger.error("306b chars not found for %s (got %d)",
+                             ctx["mac"], len(char_paths))
+                self._try_disconnect(ctx)
+                self._done(ctx, False)
+                return
+
+            ctx["char_paths"] = char_paths
+            logger.info("Found %d 306b chars for %s",
+                         len(char_paths), ctx["mac"])
+            self._step_flow_control(ctx)
+
+        def on_err(e):
+            logger.error("GetManagedObjects failed: %s", e)
+            self._done(ctx, False)
+
+        om.GetManagedObjects(reply_handler=on_objects,
+                             error_handler=on_err)
+
+    def _step_flow_control(self, ctx):
+        """Step 6: Send flow control and write register."""
+        char_paths = ctx["char_paths"]
+
+        try:
+            # Flow control
+            _write_char(self._bus, char_paths, CHAR_CONTROL,
+                         bytes([OPCODE_CHUNK_SIZE, 0x14]))
+        except Exception as e:
+            logger.warning("Flow control chunk_size failed: %s", e)
+
+        def do_write():
+            try:
+                _write_char(self._bus, char_paths, CHAR_CONTROL,
+                             bytes([OPCODE_READY_TO_RECV, 0x08]))
+            except Exception as e:
+                logger.warning("Flow control ready failed: %s", e)
+
+            # Write the register
+            cmd = (_cbor_uint(6) + _cbor_uint(0)
+                   + _cbor_array([_cbor_uint(ctx["register_id"]),
+                                  _cbor_bstr(ctx["value_bytes"])]))
+            try:
+                _write_char(self._bus, char_paths, CHAR_DATA_LAST, cmd)
+                logger.info("Wrote reg 0x%04X = %s on %s",
+                            ctx["register_id"],
+                            ctx["value_bytes"].hex(),
+                            ctx["mac"])
+            except Exception as e:
+                logger.error("Register write failed: %s", e)
+                self._try_disconnect(ctx)
+                self._done(ctx, False)
+                return False
+
+            # Disconnect after brief delay
+            GLib.timeout_add(1000, lambda: self._step_disconnect(ctx))
+            return False
+
+        GLib.timeout_add(300, do_write)
+
+    def _step_disconnect(self, ctx):
+        """Step 7: Disconnect."""
+        self._try_disconnect(ctx)
+        self._done(ctx, True)
+        return False
+
+    def _try_disconnect(self, ctx):
+        try:
+            device_obj = self._bus.get_object(
+                "org.bluez", ctx["device_path"], introspect=False)
+            device = dbus.Interface(device_obj, "org.bluez.Device1")
+            device.Disconnect(
+                reply_handler=lambda: None,
+                error_handler=lambda e: None)
+        except Exception:
+            pass
+
+
+def _write_char(bus, char_paths: dict, char_uuid: str, data: bytes):
+    path = char_paths[char_uuid]
+    # Introspect so dbus-python can auto-marshal `aya{sv}` from a
+    # plain list + dict — matches the pattern that worked on-device.
+    char_iface = dbus.Interface(
+        bus.get_object("org.bluez", path),
+        "org.bluez.GattCharacteristic1")
+    char_iface.WriteValue(list(data), {"type": "command"}, timeout=5)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/orion_tr_key_cli.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/orion_tr_key_cli.py
@@ -1,0 +1,877 @@
+#!/usr/bin/env python3
+"""Standalone Orion-TR advertisement-key fetcher.
+
+Short-lived synchronous helper that the main service shells out to
+whenever it needs to read VREG 0xEC65 from a paired Orion-TR.  Running
+as a subprocess isolates the provisioning from any long-running process
+state (bleak's BlueZ manager, dbus-python proxy cache, etc.) that we
+have seen corrupt CCCD writes after repeated connect/disconnect cycles.
+
+Usage::
+
+    python3 orion_tr_key_cli.py MAC [--passkey N] [--timeout S]
+
+On success prints the recovered 32-char hex key to stdout and exits 0.
+On failure prints a diagnostic to stderr and exits non-zero.
+
+The PUK + VREG flow follows the Victron VeSmart BLE protocol
+specification for paired GATT register access.
+"""
+from __future__ import annotations
+
+import argparse
+import binascii
+import json
+import os
+import struct
+import sys
+import time
+
+import dbus
+import dbus.mainloop.glib
+import dbus.service
+
+dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+from gi.repository import GLib  # noqa: E402
+
+SVC_306B = "306b0001-b081-4037-83dc-e59fcc3cdfd0"
+CTRL_UUID = "306b0002-b081-4037-83dc-e59fcc3cdfd0"
+DATA_LAST_UUID = "306b0003-b081-4037-83dc-e59fcc3cdfd0"
+DATA_BULK_UUID = "306b0004-b081-4037-83dc-e59fcc3cdfd0"
+C6_UUID = "97580006-ddf1-48be-b73e-182664615d8e"
+C3_UUID = "97580003-ddf1-48be-b73e-182664615d8e"
+
+AGENT_INTERFACE = "org.bluez.Agent1"
+
+
+class _PairingAgent(dbus.service.Object):
+    """BlueZ pairing agent that returns the Victron device passkey."""
+
+    def __init__(self, bus, path, passkey):
+        super().__init__(bus, path)
+        self._passkey = passkey
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="", out_signature="")
+    def Release(self):
+        pass
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="os", out_signature="")
+    def AuthorizeService(self, device, uuid):
+        pass
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="o", out_signature="u")
+    def RequestPasskey(self, device):
+        _err(f"Agent: providing passkey {self._passkey:06d}")
+        return dbus.UInt32(self._passkey)
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="ou", out_signature="")
+    def RequestConfirmation(self, device, passkey):
+        pass
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="o", out_signature="")
+    def RequestAuthorization(self, device):
+        pass
+
+    @dbus.service.method(AGENT_INTERFACE, in_signature="", out_signature="")
+    def Cancel(self):
+        pass
+
+
+def _err(*a):
+    print(*a, file=sys.stderr, flush=True)
+
+
+def _cbor_uint(n):
+    if n < 24:
+        return bytes([n])
+    if n < 256:
+        return bytes([0x18, n])
+    if n < 65536:
+        return bytes([0x19, (n >> 8) & 0xFF, n & 0xFF])
+    return bytes([0x1A, (n >> 24) & 0xFF, (n >> 16) & 0xFF,
+                  (n >> 8) & 0xFF, n & 0xFF])
+
+
+def _cbor_array(items):
+    return bytes([0x9F]) + b"".join(items) + bytes([0xFF])
+
+
+def _scan_for_key(blobs):
+    target = bytes([0x19, 0xEC, 0x65, 0x50])
+    joined = b"".join(blobs)
+    idx = joined.find(target)
+    if idx >= 0 and idx + 4 + 16 <= len(joined):
+        return joined[idx + 4 : idx + 4 + 16]
+    return None
+
+
+def _scan_for_vreg(blobs, vreg: int):
+    """Extract the byte string that a Push response carries for *vreg*.
+
+    Looks for the CBOR encoding of a uint16 register id followed by a
+    short (<24 byte) bstr header and returns the payload bytes — or
+    ``None`` if no matching entry is found in *blobs*.
+    """
+    marker = bytes([0x19, (vreg >> 8) & 0xFF, vreg & 0xFF])
+    joined = b"".join(blobs)
+    idx = 0
+    while True:
+        idx = joined.find(marker, idx)
+        if idx < 0:
+            return None
+        after = idx + len(marker)
+        if after >= len(joined):
+            return None
+        hdr = joined[after]
+        # 0x40-0x57 -> CBOR short bstr, length = hdr & 0x1F
+        if 0x40 <= hdr <= 0x57:
+            blen = hdr & 0x1F
+            start = after + 1
+            if start + blen <= len(joined):
+                return joined[start : start + blen]
+        idx = after
+
+
+def _find_bluez_device(bus, mac):
+    """Find the BlueZ device object path + adapter path across all adapters."""
+    om = dbus.Interface(bus.get_object("org.bluez", "/"),
+                        "org.freedesktop.DBus.ObjectManager")
+    objects = om.GetManagedObjects()
+    suffix = "/dev_" + mac.upper().replace(":", "_")
+    for path in sorted(objects.keys()):
+        if path.endswith(suffix) and "org.bluez.Device1" in objects[path]:
+            # adapter path is everything before /dev_
+            adapter_path = path[:path.index(suffix)]
+            return str(path), str(adapter_path)
+    # Fallback: construct from hci0
+    return ("/org/bluez/hci0" + suffix,
+            "/org/bluez/hci0")
+
+
+def _ensure_device_known(bus, mac, dev_path, adapter_path, pump_fn,
+                         scan_s=8.0):
+    """Make sure BlueZ has a live ``org.bluez.Device1`` on *dev_path*.
+    After an unbond/remove, BlueZ can drop the Device1 interface until
+    it sees another advertisement.  Start discovery briefly so the
+    peripheral's advert re-creates the object.
+    """
+    om = dbus.Interface(
+        bus.get_object("org.bluez", "/"),
+        "org.freedesktop.DBus.ObjectManager")
+    if "org.bluez.Device1" in om.GetManagedObjects().get(dev_path, {}):
+        return
+    _err(f"Device1 missing on {dev_path} — running {scan_s:.0f}s scan "
+         f"on {adapter_path}")
+    adapter = dbus.Interface(
+        bus.get_object("org.bluez", adapter_path),
+        "org.bluez.Adapter1")
+    try:
+        adapter.StartDiscovery()
+    except dbus.DBusException as e:
+        _err(f"StartDiscovery: {e}")
+    deadline = time.monotonic() + scan_s
+    found = False
+    while time.monotonic() < deadline:
+        pump_fn(500)
+        if "org.bluez.Device1" in \
+                om.GetManagedObjects().get(dev_path, {}):
+            found = True
+            break
+    try:
+        adapter.StopDiscovery()
+    except dbus.DBusException:
+        pass
+    if not found:
+        raise RuntimeError(
+            f"{mac}: BlueZ never re-created Device1 on {dev_path} "
+            f"after {scan_s:.0f}s scan")
+    _err(f"Device1 restored on {dev_path}")
+
+
+def _ensure_paired(bus, dev_path, passkey, pump_fn, timeout_s=45.0):
+    """If device isn't already paired, register a KeyboardDisplay agent
+    and call Device1.Pair() with *passkey*.  Some Orion-TR firmwares
+    (observed on 0xA3D5 48V Buck-Boost) reject unauthenticated writes to
+    the PUK characteristic, which would otherwise trigger an SMP pairing
+    attempt from BlueZ with the wrong IO capability (DisplayOnly) and
+    fail with "Invalid parameters".  Registering the agent up-front fixes
+    this for newer firmwares and is a no-op for older ones that don't
+    require pairing.
+
+    Returns an (agent, agent_path, agent_mgr) tuple to unregister later,
+    or None if the device was already paired.
+    """
+    dev_obj = bus.get_object("org.bluez", dev_path)
+    props = dbus.Interface(dev_obj, "org.freedesktop.DBus.Properties")
+    try:
+        if bool(props.Get("org.bluez.Device1", "Paired")):
+            _err(f"Already Paired=true — skipping pair step")
+            return None
+    except dbus.DBusException:
+        pass
+
+    agent_path = f"/org/victronenergy/orion_tr_keycli/agent_{os.getpid()}"
+    agent = _PairingAgent(bus, agent_path, passkey)
+    agent_mgr = dbus.Interface(
+        bus.get_object("org.bluez", "/org/bluez"),
+        "org.bluez.AgentManager1")
+    try:
+        agent_mgr.UnregisterAgent(dbus.ObjectPath(agent_path))
+    except dbus.DBusException:
+        pass
+    agent_mgr.RegisterAgent(dbus.ObjectPath(agent_path), "KeyboardDisplay")
+    agent_mgr.RequestDefaultAgent(dbus.ObjectPath(agent_path))
+    _err(f"Agent registered at {agent_path} (passkey {passkey:06d})")
+
+    try:
+        props.Set("org.bluez.Device1", "Trusted", dbus.Boolean(True))
+    except dbus.DBusException as e:
+        _err(f"Trusted set failed (non-fatal): {e}")
+
+    device = dbus.Interface(dev_obj, "org.bluez.Device1")
+    result = {"done": False, "err": None}
+
+    def on_ok():
+        result["done"] = True
+        _err("Pair() reply OK")
+
+    def on_err(e):
+        result["done"] = True
+        result["err"] = e
+        _err(f"Pair() error: {e}")
+
+    device.Pair(reply_handler=on_ok, error_handler=on_err,
+                timeout=timeout_s)
+
+    deadline = time.monotonic() + timeout_s
+    while not result["done"] and time.monotonic() < deadline:
+        pump_fn(200)
+
+    try:
+        paired = bool(props.Get("org.bluez.Device1", "Paired"))
+    except dbus.DBusException:
+        paired = False
+
+    if not paired:
+        try:
+            agent_mgr.UnregisterAgent(dbus.ObjectPath(agent_path))
+        except Exception:
+            pass
+        raise RuntimeError(
+            f"Pair() did not complete (done={result['done']}, "
+            f"err={result['err']}, Paired={paired})")
+
+    _err(f"Paired with {dev_path}")
+    return (agent, agent_path, agent_mgr)
+
+
+def _cleanup_agent(agent_info):
+    if not agent_info:
+        return
+    _agent, agent_path, agent_mgr = agent_info
+    try:
+        agent_mgr.UnregisterAgent(dbus.ObjectPath(agent_path))
+    except Exception:
+        pass
+
+
+def provision(mac, passkey, timeout_s, preferred_adapter=None):
+    bus = dbus.SystemBus()
+    dev_path, adapter_path = _find_bluez_device(bus, mac)
+
+    # If a preferred adapter is known from a prior successful connection,
+    # rewrite the paths to try it first.
+    if preferred_adapter:
+        pref_path = f"/org/bluez/{preferred_adapter}"
+        pref_dev = f"{pref_path}/dev_{mac.upper().replace(':', '_')}"
+        try:
+            bus.get_object("org.bluez", pref_dev, introspect=False)
+            _err(f"Using preferred adapter {preferred_adapter}")
+            dev_path = pref_dev
+            adapter_path = pref_path
+        except Exception:
+            _err(f"Preferred adapter {preferred_adapter} doesn't know "
+                 f"this device — falling back to {adapter_path}")
+
+    _err(f"Using {adapter_path} for {mac} (device {dev_path})")
+    ctx = GLib.MainContext.default()
+
+    def pump(ms):
+        end = time.monotonic() + ms / 1000.0
+        while time.monotonic() < end:
+            ctx.iteration(False)
+            time.sleep(0.005)
+
+    # Ensure SMP pairing / bonding exists before any GATT writes.  Some
+    # Orion-TR firmwares require an authenticated link to write to the
+    # PUK char (97580006); without a BlueZ agent registered, BlueZ would
+    # auto-pair with the wrong IO capability and the peripheral would
+    # reject with "Invalid parameters".  Register cleanup via atexit so
+    # the agent is always unregistered, regardless of how provision()
+    # exits (success, raised exception, sys.exit, kill).
+    import atexit
+    _ensure_device_known(bus, mac, dev_path, adapter_path, pump)
+    agent_info = _ensure_paired(bus, dev_path, passkey, pump)
+    if agent_info is not None:
+        atexit.register(_cleanup_agent, agent_info)
+
+    collected = []
+    bulk_buf = bytearray()
+
+    def on_last(_i, changed, _inv):
+        if "Value" not in changed:
+            return
+        data = bytes(int(b) for b in changed["Value"])
+        full = bytes(bulk_buf) + data
+        bulk_buf.clear()
+        collected.append(full)
+        _err(f"[LAST] {len(full)}B: {full.hex()}")
+
+    def on_bulk(_i, changed, _inv):
+        if "Value" not in changed:
+            return
+        data = bytes(int(b) for b in changed["Value"])
+        bulk_buf.extend(data)
+        _err(f"[BULK] +{len(data)}B: {data.hex()}")
+
+    # --- Connect ---
+    # On multi-adapter Cerbos a device may be visible on one adapter but
+    # only connectable from another.  Try the primary; on failure, scan
+    # all adapters for the same MAC and retry.
+    # le-connection-abort-by-local is a transient BlueZ error (scan/conn
+    # race) — retry the primary adapter a few times before falling back
+    # to alternates, since fallback-to-low-RSSI can "connect" then hang.
+    # Disconnect any stale session on ALL adapters first — after a
+    # prior successful provisioning the device-side session lingers
+    # and a re-PUK may be rejected until the link is torn down and
+    # re-established.
+    om_pre = dbus.Interface(bus.get_object("org.bluez", "/"),
+                            "org.freedesktop.DBus.ObjectManager")
+    suffix_pre = "/dev_" + mac.upper().replace(":", "_")
+    for p in sorted(om_pre.GetManagedObjects().keys()):
+        p = str(p)
+        if p.endswith(suffix_pre):
+            try:
+                dbus.Interface(
+                    bus.get_object("org.bluez", p),
+                    "org.bluez.Device1").Disconnect()
+                _err(f"Pre-disconnected {p}")
+            except dbus.DBusException:
+                pass
+    pump(1500)
+
+    _err(f"Connecting to {mac} via {dev_path}...")
+    connected = False
+    for attempt in range(1, 5):
+        try:
+            dev_obj = bus.get_object("org.bluez", dev_path)
+            dbus.Interface(dev_obj, "org.bluez.Device1").Connect()
+            connected = True
+            break
+        except dbus.DBusException as e:
+            if "Already Connected" in str(e):
+                dev_obj = bus.get_object("org.bluez", dev_path)
+                connected = True
+                break
+            _err(f"  Connect attempt {attempt}/4 on {dev_path}: {e}")
+            pump(1500)
+
+    if not connected:
+        # Try every other adapter that knows this MAC
+        om = dbus.Interface(bus.get_object("org.bluez", "/"),
+                            "org.freedesktop.DBus.ObjectManager")
+        suffix = "/dev_" + mac.upper().replace(":", "_")
+        for p in sorted(om.GetManagedObjects().keys()):
+            p = str(p)
+            if p.endswith(suffix) and p != dev_path:
+                _err(f"  Trying alternate {p}...")
+                try:
+                    dev_obj = bus.get_object("org.bluez", p)
+                    dbus.Interface(dev_obj, "org.bluez.Device1").Connect()
+                    dev_path = p
+                    adapter_path = p[:p.index(suffix)]
+                    connected = True
+                    _err(f"  Connected via {adapter_path}")
+                    break
+                except dbus.DBusException as e2:
+                    if "Already Connected" in str(e2):
+                        dev_obj = bus.get_object("org.bluez", p)
+                        dev_path = p
+                        connected = True
+                        break
+                    _err(f"  Also failed: {e2}")
+
+    if not connected:
+        raise RuntimeError(f"Cannot connect to {mac} on any adapter")
+
+    device = dbus.Interface(dev_obj, "org.bluez.Device1")
+    dev_props = dbus.Interface(dev_obj, "org.freedesktop.DBus.Properties")
+    services_ok = False
+    for _ in range(60):  # up to 30s — post-pair discovery can be slow
+        pump(500)
+        try:
+            if bool(dev_props.Get("org.bluez.Device1", "ServicesResolved")):
+                services_ok = True
+                break
+        except dbus.DBusException:
+            pass
+
+    # If services didn't resolve, the adapter may have a stale
+    # connection.  Disconnect and try other adapters.
+    if not services_ok:
+        _err(f"ServicesResolved timed out on {dev_path} — trying other adapters")
+        try:
+            device.Disconnect()
+        except Exception:
+            pass
+        pump(1000)
+        om = dbus.Interface(bus.get_object("org.bluez", "/"),
+                            "org.freedesktop.DBus.ObjectManager")
+        suffix = "/dev_" + mac.upper().replace(":", "_")
+        for p in sorted(om.GetManagedObjects().keys()):
+            p = str(p)
+            if p.endswith(suffix) and p != dev_path:
+                _err(f"  Trying {p}...")
+                try:
+                    dev_obj = bus.get_object("org.bluez", p)
+                    dbus.Interface(dev_obj, "org.bluez.Device1").Connect()
+                    dev_props = dbus.Interface(dev_obj,
+                                              "org.freedesktop.DBus.Properties")
+                    for _ in range(60):  # up to 30s
+                        pump(500)
+                        try:
+                            if bool(dev_props.Get("org.bluez.Device1",
+                                                  "ServicesResolved")):
+                                services_ok = True
+                                dev_path = p
+                                device = dbus.Interface(dev_obj,
+                                                        "org.bluez.Device1")
+                                _err(f"  Services resolved on {p}")
+                                break
+                        except dbus.DBusException:
+                            pass
+                    if services_ok:
+                        break
+                except dbus.DBusException as e2:
+                    _err(f"  Failed: {e2}")
+
+    if not services_ok:
+        raise RuntimeError("ServicesResolved never fired on any adapter")
+    _err("Connected.")
+
+    # --- Discover chars ---
+    om = dbus.Interface(bus.get_object("org.bluez", "/"),
+                        "org.freedesktop.DBus.ObjectManager")
+    objects = om.GetManagedObjects()
+    chars_9758 = {}
+    chars_306b = {}
+    for path, ifs in objects.items():
+        if "org.bluez.GattCharacteristic1" not in ifs:
+            continue
+        if not path.startswith(dev_path):
+            continue
+        cp = ifs["org.bluez.GattCharacteristic1"]
+        uuid = str(cp.get("UUID", ""))
+        svc_path = str(cp.get("Service", ""))
+        if uuid.startswith("9758"):
+            chars_9758[uuid] = path
+        elif uuid.startswith("306b") and svc_path in objects:
+            si = objects[svc_path]
+            if "org.bluez.GattService1" in si:
+                if str(si["org.bluez.GattService1"].get("UUID", "")) == SVC_306B:
+                    chars_306b[uuid] = path
+
+    if C6_UUID not in chars_9758:
+        raise RuntimeError("PUK characteristic 9758…06 not found")
+    if CTRL_UUID not in chars_306b or DATA_LAST_UUID not in chars_306b:
+        raise RuntimeError("306b CTRL/DATA_LAST not found")
+
+    ci6 = dbus.Interface(bus.get_object("org.bluez", chars_9758[C6_UUID]),
+                         "org.bluez.GattCharacteristic1")
+    ctrl = dbus.Interface(bus.get_object("org.bluez", chars_306b[CTRL_UUID]),
+                          "org.bluez.GattCharacteristic1")
+    dlast = dbus.Interface(bus.get_object("org.bluez", chars_306b[DATA_LAST_UUID]),
+                           "org.bluez.GattCharacteristic1")
+
+    # On Venus OS, StartNotify + PropertiesChanged signals deliver empty
+    # payloads for the 306b characteristics when the link is SMP-paired
+    # (see 9758-VESERVICE-RESEARCH.md).  Use AcquireNotify instead: it
+    # returns a Unix fd that delivers raw ATT notification bytes, which
+    # we read in a GLib IO watch.
+    notify_fds = []
+
+    def _acquire_notify(char_iface, char_path, label, on_bytes):
+        try:
+            ret = char_iface.AcquireNotify({})
+            # ret is (fd: dbus.types.UnixFd, mtu: uint16)
+            fd = ret[0].take() if hasattr(ret[0], "take") else int(ret[0])
+            mtu = int(ret[1]) if len(ret) > 1 else 0
+            _err(f"AcquireNotify {label}: fd={fd} mtu={mtu}")
+            notify_fds.append(fd)
+
+            def on_io(source, cond):
+                if cond & (GLib.IO_HUP | GLib.IO_ERR | GLib.IO_NVAL):
+                    _err(f"{label} fd closed (cond={cond})")
+                    return False
+                try:
+                    data = os.read(source, 512)
+                except OSError as e:
+                    _err(f"{label} read: {e}")
+                    return False
+                if data:
+                    on_bytes(data)
+                return True
+
+            GLib.io_add_watch(
+                fd, GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR, on_io)
+            return True
+        except dbus.DBusException as e:
+            _err(f"AcquireNotify {label} failed ({e}); falling back "
+                 f"to StartNotify")
+            return False
+
+    def on_last_bytes(data):
+        full = bytes(bulk_buf) + data
+        bulk_buf.clear()
+        collected.append(full)
+        _err(f"[LAST] {len(full)}B: {full.hex()}")
+
+    def on_bulk_bytes(data):
+        bulk_buf.extend(data)
+        _err(f"[BULK] +{len(data)}B: {data.hex()}")
+
+    def on_ctrl_bytes(data):
+        # Just log device-side CTRL traffic (F7 Error, F9 credits, F8
+        # buffer-clear).  The handshake is driven explicitly below by
+        # a CTRL ReadValue + FA/F9 writes — do NOT do it here or we
+        # race ourselves.
+        if data:
+            _err(f"[CTRL-RX] {len(data)}B: {data.hex()}")
+
+    # Enable notifications on CTRL first — the device needs CCCD on
+    # 306b0002 before it will push its session header to us.
+    if not _acquire_notify(ctrl, chars_306b[CTRL_UUID],
+                           "CTRL", on_ctrl_bytes):
+        bus.add_signal_receiver(
+            lambda _i, ch, _inv: on_ctrl_bytes(
+                bytes(int(b) for b in ch["Value"])
+                if "Value" in ch else b""),
+            dbus_interface="org.freedesktop.DBus.Properties",
+            signal_name="PropertiesChanged",
+            path=chars_306b[CTRL_UUID])
+        ctrl.StartNotify()
+
+    if not _acquire_notify(dlast, chars_306b[DATA_LAST_UUID],
+                           "DATA_LAST", on_last_bytes):
+        bus.add_signal_receiver(
+            on_last,
+            dbus_interface="org.freedesktop.DBus.Properties",
+            signal_name="PropertiesChanged",
+            path=chars_306b[DATA_LAST_UUID])
+        dlast.StartNotify()
+
+    if DATA_BULK_UUID in chars_306b:
+        dbulk = dbus.Interface(
+            bus.get_object("org.bluez", chars_306b[DATA_BULK_UUID]),
+            "org.bluez.GattCharacteristic1")
+        if not _acquire_notify(dbulk, chars_306b[DATA_BULK_UUID],
+                               "DATA_BULK", on_bulk_bytes):
+            bus.add_signal_receiver(
+                on_bulk,
+                dbus_interface="org.freedesktop.DBus.Properties",
+                signal_name="PropertiesChanged",
+                path=chars_306b[DATA_BULK_UUID])
+            dbulk.StartNotify()
+
+    pump(500)
+
+    # --- Always-on PUK notify receiver (used by optional auth below) ---
+    puk_responses = []
+
+    def on_puk(_i, changed, _inv):
+        if "Value" not in changed:
+            return
+        puk_responses.append(bytes(int(b) for b in changed["Value"]))
+        _err(f"[PUK] {len(puk_responses[-1])}B: {puk_responses[-1].hex()}")
+
+    bus.add_signal_receiver(
+        on_puk,
+        dbus_interface="org.freedesktop.DBus.Properties",
+        signal_name="PropertiesChanged",
+        path=chars_9758[C6_UUID])
+    ci6.StartNotify()
+    pump(200)
+
+    def _do_puk_pin_auth():
+        """Full PUK CRC + PIN auth on 9758 service.  Needed on the very
+        first provisioning of a device whose firmware enforces the
+        PUK+PIN path; already-bonded devices skip this (fast path)."""
+        # PUK CRC
+        puk_ok = False
+        for attempt in range(1, 4):
+            puk_responses.clear()
+            nonce = bytes(int(b) for b in ci6.ReadValue({}))
+            crc = binascii.crc32(nonce) & 0xFFFFFFFF
+            crc_bytes = struct.pack("<I", crc)
+            _err(f"PUK auth attempt {attempt}: nonce={nonce.hex()} "
+                 f"crc={crc_bytes.hex()}")
+            ci6.WriteValue(list(crc_bytes), {"type": "command"})
+            pump(1500)
+            if any(d == b"\x00" for d in puk_responses):
+                puk_ok = True
+                _err("PUK CRC OK")
+                break
+            _err(f"PUK attempt {attempt} rejected (responses="
+                 f"{[d.hex() for d in puk_responses]})")
+            pump(500)
+        if not puk_ok:
+            raise RuntimeError("PUK CRC not accepted after 3 attempts")
+
+        # PIN auth on c3 (97580003) — nonce + LE32(passkey), 12 bytes.
+        # Needed on 0xA3D5 firmware; harmless on older devices.
+        if C3_UUID in chars_9758:
+            c3 = dbus.Interface(
+                bus.get_object("org.bluez", chars_9758[C3_UUID]),
+                "org.bluez.GattCharacteristic1")
+            c3_responses = []
+
+            def on_c3(_i, changed, _inv):
+                if "Value" not in changed:
+                    return
+                c3_responses.append(
+                    bytes(int(b) for b in changed["Value"]))
+                _err(f"[C3] {len(c3_responses[-1])}B: "
+                     f"{c3_responses[-1].hex()}")
+
+            bus.add_signal_receiver(
+                on_c3,
+                dbus_interface="org.freedesktop.DBus.Properties",
+                signal_name="PropertiesChanged",
+                path=chars_9758[C3_UUID])
+            try:
+                c3.StartNotify()
+                pump(200)
+                fresh_nonce = bytes(
+                    int(b) for b in ci6.ReadValue({}))
+                pin_payload = (fresh_nonce
+                               + struct.pack("<I", passkey))
+                _err(f"PIN auth: nonce+PIN = {pin_payload.hex()}")
+                c3.WriteValue(list(pin_payload), {"type": "command"})
+                pump(2000)
+                if any(r == b"\x00" for r in c3_responses):
+                    _err("PIN accepted")
+                else:
+                    _err(f"PIN responses="
+                         f"{[r.hex() for r in c3_responses]}"
+                         f" — continuing anyway")
+            except dbus.DBusException as e:
+                _err(f"PIN step failed (non-fatal): {e}")
+
+    # --- CTRL READ (critical!) ---
+    # Reading the CTRL characteristic triggers the device's CBOR-mode
+    # initialisation.  Skipping the read leaves the device's response
+    # pipeline disabled — DATA_LAST never fires.  Do the read after
+    # auth and follow up with our FA/F9 handshake writes.
+    try:
+        ctrl_hdr = bytes(int(b) for b in ctrl.ReadValue({}))
+        _err(f"CTRL header: {ctrl_hdr.hex()}")
+    except dbus.DBusException as e:
+        _err(f"CTRL ReadValue: {e} — proceeding anyway")
+    ctrl.WriteValue([0xFA, 0x80, 0xFF], {"type": "command"})
+    pump(300)
+    ctrl.WriteValue([0xF9, 0x80], {"type": "command"})
+    pump(400)
+
+    # --- Prime: Subscribe to a chatty public VREG to wake the pipe ---
+    # A GetValue 0x25 sent as the very first CBOR request sometimes
+    # gets swallowed before the device has established its outgoing
+    # stream.  Sending a plain subscribe first forces the device to
+    # start pushing and keeps credits flowing.
+    prime = bytes([0x03, 0x00, 0x9F, 0x19, 0xED, 0xDB, 0xFF])
+    _err(f"Subscribe 0xEDDB (prime): {prime.hex()}")
+    dlast.WriteValue(list(prime), {"type": "command"})
+    prime_deadline = time.monotonic() + 3.0
+    while time.monotonic() < prime_deadline and not collected:
+        pump(400)
+        try:
+            ctrl.WriteValue([0xF9, 0x80], {"type": "command"})
+        except Exception:
+            pass
+
+    # --- GetValue 0xEC65 (fast path, then PUK+PIN fallback) ---
+    # Opcode 0x25 (not 0x05) is the "privileged" GetValue variant for
+    # the advertisement-key register.  Plain 0x05 returns
+    # "RequestedEncryptionNotSupported" (error code 2) for this reg.
+    # The fast path skips PUK+PIN — sufficient for already-bonded
+    # devices (e.g. daily refresh).  On error 2 we fall back to full
+    # auth and retry once.
+    cmd = bytes([0x25, 0x00, 0x9F, 0x19, 0xEC, 0x65, 0xFF])
+
+    def _scan_for_encryption_error(blobs):
+        # ACK error 2 format: `07 19 EC 65 05 02` or `07 19 EC 65 25 02`.
+        # Any frame ending in `19 EC 65 <opcode> 02` signals encryption
+        # refused.
+        j = b"".join(blobs)
+        for tail in (b"\x19\xec\x65\x05\x02",
+                     b"\x19\xec\x65\x25\x02"):
+            if tail in j:
+                return True
+        return False
+
+    key = None
+    for attempt_phase in ("fast", "authed"):
+        collected.clear()
+        bulk_buf.clear()
+        _err(f"GetValue 0xEC65 ({attempt_phase}, opcode 0x25): "
+             f"{cmd.hex()}")
+        dlast.WriteValue(list(cmd), {"type": "command"})
+        phase_deadline = time.monotonic() + (
+            min(timeout_s, 15.0) if attempt_phase == "authed" else 6.0)
+        refused = False
+        while time.monotonic() < phase_deadline:
+            pump(500)
+            key = _scan_for_key(collected)
+            if key is not None:
+                _err(f"Recovered key: {len(key)}B")
+                break
+            if _scan_for_encryption_error(collected):
+                refused = True
+                _err("Device refused with encryption error — "
+                     "falling back to PUK+PIN auth")
+                break
+            try:
+                ctrl.WriteValue([0xF9, 0x80], {"type": "command"})
+            except Exception:
+                pass
+        if key is not None:
+            break
+        if attempt_phase == "fast" and refused:
+            _do_puk_pin_auth()
+            # Re-do CTRL read + handshake after auth (session may reset)
+            try:
+                _ = bytes(int(b) for b in ctrl.ReadValue({}))
+            except dbus.DBusException:
+                pass
+            try:
+                ctrl.WriteValue([0xFA, 0x80, 0xFF], {"type": "command"})
+                pump(300)
+                ctrl.WriteValue([0xF9, 0x80], {"type": "command"})
+                pump(400)
+            except dbus.DBusException:
+                pass
+            # Re-prime
+            dlast.WriteValue(
+                list(bytes([0x03, 0x00, 0x9F, 0x19, 0xED, 0xDB, 0xFF])),
+                {"type": "command"})
+            pump(1500)
+            continue
+        # fast succeeded → we already broke above; or authed failed → exit
+        break
+
+    if key is None:
+        try:
+            device.Disconnect()
+        except Exception:
+            pass
+        raise RuntimeError(
+            f"no 16-byte key in VREG 0xEC65 response "
+            f"({len(collected)} chunks, "
+            f"{sum(len(c) for c in collected)}B total)")
+
+    # --- Opportunistically read firmware (0x0140) and product id ------
+    # (0x0100) in the same paired session, one more GetValue round-trip
+    # each.  We don't fail the whole flow if a register is unavailable —
+    # some firmwares may not expose a particular register.
+    def _fetch_vreg(vreg: int, label: str,
+                    timeout: float = 4.0) -> str:
+        try:
+            req = (_cbor_uint(0x05) + _cbor_uint(0)
+                   + _cbor_array([_cbor_uint(vreg)]))
+            collected.clear()
+            bulk_buf.clear()
+            _err(f"GetValue 0x{vreg:04X} ({label}): {req.hex()}")
+            dlast.WriteValue(list(req), {"type": "request"})
+            deadline_local = time.monotonic() + timeout
+            while time.monotonic() < deadline_local:
+                pump(400)
+                val = _scan_for_vreg(collected, vreg)
+                if val is not None:
+                    _err(f"Recovered {label} bytes: {val.hex()}")
+                    return val.hex()
+                try:
+                    ctrl.WriteValue([0xF9, 0x08], {"type": "command"})
+                except Exception:
+                    pass
+        except Exception as e:
+            _err(f"{label} read failed (non-fatal): {e}")
+        return None
+
+    firmware_hex = _fetch_vreg(0x0140, "firmware")
+    product_id_hex = _fetch_vreg(0x0100, "product id")
+    temperature_hex = _fetch_vreg(0xEDDB, "temperature")
+
+    # Read DeviceInfo (97580002) for hardware version — this is a plain
+    # GATT ReadValue, no CBOR/flow-control needed.
+    hw_version = None
+    try:
+        if "97580002-ddf1-48be-b73e-182664615d8e" in chars_9758:
+            di_iface = dbus.Interface(
+                bus.get_object("org.bluez",
+                               chars_9758["97580002-ddf1-48be-b73e-182664615d8e"]),
+                "org.bluez.GattCharacteristic1")
+            di_val = bytes(int(b) for b in di_iface.ReadValue({}))
+            _err(f"DeviceInfo: {len(di_val)}B: {di_val.hex()}")
+            if len(di_val) >= 4:
+                hw_rev = int.from_bytes(di_val[2:4], "little")
+                hw_version = str(hw_rev)
+                _err(f"Hardware revision: {hw_version}")
+    except Exception as e:
+        _err(f"DeviceInfo read failed (non-fatal): {e}")
+
+    for _fd in notify_fds:
+        try:
+            os.close(_fd)
+        except Exception:
+            pass
+    notify_fds.clear()
+    try:
+        device.Disconnect()
+    except Exception:
+        pass
+
+    # Extract which adapter we ended up using (e.g. "hci1") so the
+    # caller can persist it for next time.
+    used_adapter = adapter_path.rsplit("/", 1)[-1] if "/" in adapter_path \
+        else adapter_path
+
+    return {
+        "key": key.hex(),
+        "firmware": firmware_hex,
+        "product_id": product_id_hex,
+        "temperature": temperature_hex,
+        "hardware_version": hw_version,
+        "adapter": used_adapter,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    ap.add_argument("mac")
+    ap.add_argument("--passkey", type=int, default=0)
+    ap.add_argument("--timeout", type=float, default=40.0)
+    ap.add_argument("--preferred-adapter", default=None,
+                    help="Try this adapter first (e.g. hci1)")
+    args = ap.parse_args()
+    try:
+        result = provision(args.mac, args.passkey, args.timeout,
+                           preferred_adapter=args.preferred_adapter)
+    except Exception as e:
+        _err(f"orion-tr key provisioning failed: {e}")
+        return 1
+    sys.stdout.write(json.dumps(result) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/opt/victronenergy/dbus-ble-sensors-py/orion_tr_key_settings.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/orion_tr_key_settings.py
@@ -1,0 +1,124 @@
+"""
+Persist Orion-TR BLE advertisement keys in ``com.victronenergy.settings``.
+
+Paths are created with ``AddSilentSetting`` so they stay out of the normal
+settings picker UI, but remain in the settings database for backup/restore.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+from dbus_settings_service import DbusSettingsService
+
+logger = logging.getLogger(__name__)
+
+
+def _mac_key(dev_mac: str) -> str:
+    """``dev_mac`` as used elsewhere in dbus-ble-sensors-py (12 hex chars, no colons)."""
+    s = dev_mac.lower().replace(":", "")
+    if not re.fullmatch(r"[0-9a-f]{12}", s):
+        raise ValueError(f"invalid dev_mac: {dev_mac!r}")
+    return s
+
+
+def advertisement_key_setting_path(dev_mac: str) -> str:
+    """Silent setting path for a device's 16-byte advertisement key.
+
+    ``/Settings/Services/BleSensors`` is already registered as a leaf
+    boolean (the global service enable switch); localsettings refuses to
+    also register a GroupObject at that path, so we keep the Orion-TR
+    keys under ``/Settings/Devices/orion_tr_<mac>/`` — the same tree the
+    service already uses for per-device ``CustomName`` and ``Enabled``
+    entries.
+    """
+    mk = _mac_key(dev_mac)
+    return f"/Settings/Devices/orion_tr_{mk}/AdvertisementKey"
+
+
+def get_advertisement_key(settings: DbusSettingsService, dev_mac: str) -> Optional[str]:
+    path = advertisement_key_setting_path(dev_mac)
+    raw = settings.try_get_value(path)
+    if raw is None:
+        return None
+    s = str(raw).strip().lower().replace(" ", "")
+    if len(s) != 32 or any(c not in "0123456789abcdef" for c in s):
+        return None
+    return s
+
+
+def set_advertisement_key(settings: DbusSettingsService, dev_mac: str, key_hex: str) -> None:
+    """Store 32-character hex key (16 bytes) into ``com.victronenergy.settings``.
+
+    ``AddSilentSetting`` only seeds the *default* value of a path; if the
+    setting already exists with a different current value (for example
+    after a manual clear or a previously-persisted stale key), the add is
+    a no-op on the live value.  We therefore ensure the setting exists
+    and then write the live value with ``BusItem.SetValue``.
+    """
+    mk = _mac_key(dev_mac)
+    s = str(key_hex).strip().lower().replace(" ", "")
+    if len(s) != 32 or any(c not in "0123456789abcdef" for c in s):
+        raise ValueError("key must be 32 hex characters")
+    path = advertisement_key_setting_path(dev_mac)
+    # Ensure the path exists (creates it on first run, seeds default).
+    settings.set_item(path, s, 0, 0, silent=True)
+    # Then push the actual value so a stale existing setting is replaced.
+    settings.set_value(path, s)
+    logger.info("Stored Orion-TR advertisement key for %s", mk)
+
+
+def firmware_version_setting_path(dev_mac: str) -> str:
+    """Silent setting path for the cached firmware version string."""
+    return f"/Settings/Devices/orion_tr_{_mac_key(dev_mac)}/FirmwareVersion"
+
+
+def get_firmware_version(settings: DbusSettingsService,
+                        dev_mac: str) -> Optional[str]:
+    path = firmware_version_setting_path(dev_mac)
+    raw = settings.try_get_value(path)
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s or None
+
+
+def preferred_adapter_setting_path(dev_mac: str) -> str:
+    return f"/Settings/Devices/orion_tr_{_mac_key(dev_mac)}/PreferredAdapter"
+
+
+def get_preferred_adapter(settings: DbusSettingsService,
+                          dev_mac: str) -> Optional[str]:
+    path = preferred_adapter_setting_path(dev_mac)
+    raw = settings.try_get_value(path)
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s or None
+
+
+def set_preferred_adapter(settings: DbusSettingsService,
+                          dev_mac: str, adapter: str) -> None:
+    """Store which BlueZ adapter (e.g. ``hci1``) last connected successfully."""
+    mk = _mac_key(dev_mac)
+    s = str(adapter).strip()
+    if not s:
+        return
+    path = preferred_adapter_setting_path(dev_mac)
+    settings.set_item(path, s, 0, 0, silent=True)
+    settings.set_value(path, s)
+    logger.info("Stored preferred adapter %s for Orion-TR %s", s, mk)
+
+
+def set_firmware_version(settings: DbusSettingsService,
+                         dev_mac: str, version: str) -> None:
+    """Persist the firmware version string (free-form) in silent settings."""
+    mk = _mac_key(dev_mac)
+    s = str(version).strip()
+    if not s:
+        return
+    path = firmware_version_setting_path(dev_mac)
+    settings.set_item(path, s, 0, 0, silent=True)
+    settings.set_value(path, s)
+    logger.info("Stored Orion-TR firmware version %r for %s", s, mk)

--- a/src/opt/victronenergy/dbus-ble-sensors-py/orion_tr_pin.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/orion_tr_pin.py
@@ -1,0 +1,74 @@
+"""
+Resolve BLE pairing passkey for Orion-TR SMP / Victron pairing agent.
+
+Order (highest priority first):
+1. Optional ini: ``/data/conf/dbus-ble-sensors-py-orion.ini`` ``[orion] PairingPin``
+2. Cerbo GX setting: ``/Settings/Ble/Service/Pincode`` (see gui-v2 ``PageSettingsBluetooth.qml``)
+3. Default ``0`` (six-digit passkey ``000000`` in the BlueZ agent UI sense)
+"""
+from __future__ import annotations
+
+import configparser
+import logging
+import os
+import re
+from typing import Optional
+
+from dbus_settings_service import DbusSettingsService
+
+from conf import ORION_OPTIONAL_INI
+
+logger = logging.getLogger(__name__)
+
+CERBO_BLE_SERVICE_PINCODE = "/Settings/Ble/Service/Pincode"
+
+
+def _parse_ini_pin() -> Optional[int]:
+    path = ORION_OPTIONAL_INI
+    if not path or not os.path.isfile(path):
+        return None
+    try:
+        cfg = configparser.ConfigParser()
+        cfg.read(path)
+        if not cfg.has_section("orion"):
+            return None
+        raw = cfg.get("orion", "PairingPin", fallback="").strip()
+        if not raw:
+            return None
+        return int(re.sub(r"\D", "", raw))
+    except Exception:
+        logger.exception("Failed to read optional Orion pairing pin from %r", path)
+        return None
+
+
+def _coerce_pin_value(raw) -> Optional[int]:
+    if raw is None:
+        return None
+    if isinstance(raw, (int,)):
+        return int(raw)
+    s = str(raw).strip()
+    if not s:
+        return None
+    digits = re.sub(r"\D", "", s)
+    if not digits:
+        return None
+    try:
+        return int(digits)
+    except ValueError:
+        return None
+
+
+def resolve_pairing_passkey(settings: DbusSettingsService) -> int:
+    override = _parse_ini_pin()
+    if override is not None:
+        logger.debug("Orion pairing passkey: from %r", ORION_OPTIONAL_INI)
+        return override
+
+    cerbo = settings.try_get_value(CERBO_BLE_SERVICE_PINCODE)
+    pin = _coerce_pin_value(cerbo)
+    if pin is not None:
+        logger.debug("Orion pairing passkey: from Cerbo %r", CERBO_BLE_SERVICE_PINCODE)
+        return pin
+
+    logger.debug("Orion pairing passkey: default 0 (000000)")
+    return 0

--- a/src/opt/victronenergy/dbus-ble-sensors-py/scan_control.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/scan_control.py
@@ -1,0 +1,48 @@
+"""
+Shared pause/resume hooks for the ``BleakScanner`` main loop.
+
+Some drivers (currently the Orion-TR integration) need exclusive GATT
+access to ``hci0`` for pairing, notifications and register reads.  Leaving
+``bleak.BleakScanner`` running at the same time triggers
+``org.bluez.Error.InProgress`` errors from BlueZ and starves out the
+``PropertiesChanged`` signals that we subscribe to.
+
+The orchestration is intentionally tiny: a reference-counted pause flag
+that the scan loop polls between iterations.  Drivers wrap their GATT
+bursts in :func:`pause_scanning` / :func:`resume_scanning` calls.  The
+scan loop in :mod:`dbus_ble_sensors` checks :func:`is_scanning_paused`
+between iterations and idles instead of starting a fresh scanner while
+the flag is set.
+
+Lives in its own module to avoid an import cycle between
+``dbus_ble_sensors`` and driver modules that pause/resume scanning.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_refs = 0
+
+
+def pause_scanning(reason: str = "") -> None:
+    global _refs
+    _refs += 1
+    if _refs == 1:
+        logger.info("BLE scan loop paused (%s)", reason or "unspecified")
+
+
+def resume_scanning(reason: str = "") -> None:
+    global _refs
+    if _refs <= 0:
+        logger.warning("resume_scanning called while not paused")
+        _refs = 0
+        return
+    _refs -= 1
+    if _refs == 0:
+        logger.info("BLE scan loop resumed (%s)", reason or "unspecified")
+
+
+def is_scanning_paused() -> bool:
+    return _refs > 0


### PR DESCRIPTION
## Dependency

**Depends on #2** (Replace Bleak with raw HCI monitor channel for BLE advertisement capture).

The Orion-TR key-provisioning and daily-refresh flows need exclusive GATT access to the adapter while they pair, subscribe to notifications and read CBOR registers. Active `BleakScanner`-based discovery on the same adapter contends with those operations (`org.bluez.Error.InProgress`, silent `StartNotify` failures, `le-connection-abort-by-local`). The passive HCI monitor-channel tap in #2 eliminates that contention because it observes advertisements at the kernel HCI layer without issuing `StartDiscovery`.

This PR coordinates with whichever scanner the host runs via a small ref-counted pause flag (`scan_control.py`) and was validated end-to-end on top of the #2 passive tap.

## Summary

Adds full Victron Orion-TR Smart (product IDs 0xA3C0–0xA3DF) support:

- **Automatic advertisement key provisioning** via PUK CRC authentication + VREG 0xEC65 read (subprocess-isolated for BlueZ stability)
- **Encrypted advertisement decoding** via vendored `victron_ble` library (patched for `cryptography` — no PyCryptodome needed on Venus OS)
- **`/Mode` GATT write** for on/off control (paired, encrypted CBOR SetValue on VREG 0x0200)
- **`dcdc` ↔ `alternator` service role flip** based on device operating state
- **Daily morning GATT refresh** (3–5 AM, in-range only) for firmware version and temperature
- **Multi-adapter HCI support** (discovers device across all BlueZ adapters, not hardcoded to hci0)

### D-Bus paths published

| Path | Source |
|------|--------|
| `/ProductName` | `victron_ble` model-id lookup, with in-driver fallback for undocumented SKUs (e.g. 0xA3D5 "Orion-TR Smart 48/24-12A") |
| `/FirmwareVersion` | VREG 0x0140 (BCD decoded, e.g. "1.10") |
| `/HardwareVersion` | DeviceInfo characteristic 97580002 |
| `/Dc/In/V`, `/Dc/0/Voltage` | Encrypted advertisement (real-time) |
| `/Dc/0/Temperature` | VREG 0xEDDB (daily GATT refresh) |
| `/State`, `/ErrorCode`, `/DeviceOffReason` | Encrypted advertisement |
| `/Mode` | Writable (1=On, 4=Off → GATT write) |

### Paired-firmware (0xA3D5) key-provisioning support

Newer Orion-TR firmware (seen on the 48V "Orion-TR Smart 48/24-12A", product 0xA3D5) enforces a stricter key-exchange flow. The provisioning CLI now transparently handles both variants:

- SMP pairing via a BlueZ `KeyboardDisplay` Agent that supplies the Victron passkey when the device demands authentication before exposing the PUK char.
- PIN auth on characteristic `97580003` (`nonce || LE32(passkey)`) in addition to the existing PUK CRC on `97580006`.
- CTRL (`306b0002`) `ReadValue` to initialise the device's CBOR response pipeline; otherwise `DATA_LAST` notifications never fire on paired links.
- `AcquireNotify` (fd-based) in place of `StartNotify` on the 306b characteristics — on Venus OS with encrypted links, `StartNotify`-delivered signals arrive with empty payloads.
- Flow-control handshake `FA 80 FF` / `F9 80` so the host-side credit accumulator actually crosses its flush threshold.
- Prime-subscribe on a chatty public VREG before the key read to wake the response pipe.
- `GetValue` opcode `0x25` (privileged variant) for VREG `0xEC65`; plain `0x05` is refused on this firmware with ACK error code 2 ("RequestedEncryptionNotSupported").
- Fast-path-first: skip PUK+PIN when the device already trusts us; fall back to full auth only on the encryption-refused ACK. Keeps the daily-refresh path fast for bonded devices.

### Files

- `ble_device_orion_tr.py` — main device driver
- `orion_tr_key_cli.py` — subprocess provisioner (PUK + PIN + VREG reads)
- `orion_tr_gatt.py` — async GATT register writer for `/Mode`
- `orion_tr_key_settings.py` — silent settings for key, firmware, and preferred adapter
- `orion_tr_pin.py` — pairing passkey resolution
- `ble_role_dcdc.py`, `ble_role_alternator.py` — role services
- `scan_control.py` — scanner pause/resume hooks for GATT operations
- `docs/ORION-TR-INTEGRATION.md` — architecture + deployment docs

### Tested on

- Cerbo GX (Venus OS v3.72, armv7l)
- Orion Smart 12V/24V-15A (product ID 0xA3C9, firmware 1.10)
- Orion-TR Smart 48/24-12A (product ID 0xA3D5) — previously-blocked 48V unit, now provisions cleanly
- End-to-end verified on top of #2 against three paired Orion-TRs on a single cerbo and a separate 12V/24V Orion on a second cerbo — each returns the correct 16-byte advertisement key in repeated consecutive runs with bluetoothd stable.
- gui-v2 verified: Settings → Devices shows device with Switch toggle, voltages, state, error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)