### PR TITLE
DbusSettingsService: stop leaking match rules on cache miss

### DIFF
--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_settings_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_settings_service.py
@@ -28,38 +28,74 @@ class DbusSettingsService(object):
 
     def get_item(self, path: str, def_value: object = None, min_value: int = 0, max_value: int = 0) -> VeDbusItemImport:
         # Get the setting item, initializing it only if it does not exists and if a default value is given
-        if (item := self._paths.get(path, None)) is None:
-            item = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, path)
-            if not item.exists and def_value is not None:
-                item = self.set_item(path, def_value, min_value, max_value)
-            self._paths[path] = item
+        if (item := self._paths.get(path, None)) is not None:
+            return item
+
+        # Probe existence with a non-subscribing import.  Each
+        # ``VeDbusItemImport`` constructed with ``createsignal=True``
+        # (the default) installs a D-Bus match rule that is owned by
+        # the connection, not by the Python object — once the rule is
+        # in place the daemon counts it against the per-connection
+        # ``max_match_rules_per_connection`` limit (1024 by default)
+        # even after the import is garbage-collected.  Probe without
+        # subscribing so a single long-lived signal-bearing import is
+        # the only rule we add per cache miss.
+        probe = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, path, createsignal=False)
+
+        if not probe.exists:
+            if def_value is None:
+                # Nothing to bind a subscription to.  Cache the probe so
+                # repeated lookups don't re-probe; callers that depend on
+                # ``.exists`` will see False.
+                self._paths[path] = probe
+                return probe
+            return self._add_and_subscribe(path, def_value, min_value, max_value, silent=False, callback=None)
+
+        # Setting exists; bind exactly one signal-bearing import.
+        item = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, path)
+        self._paths[path] = item
         return item
 
     def get_value(self, path) -> object:  # int, float, str, None
         return self.get_item(path).get_value()
 
     def set_item(self, path: str, def_value: object = None, min_value: int = 0, max_value: int = 0, silent=False, callback=None) -> VeDbusItemImport:
+        # Probe existence and current attributes without subscribing — see
+        # the ``get_item`` comment for why we cannot afford a throwaway
+        # signal-bearing import here.
+        probe = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, path, createsignal=False)
+
+        if probe.exists and (def_value, min_value, max_value, silent) == probe._proxy.GetAttributes():
+            item = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, path, callback)
+            self._paths[path] = item
+            return item
+
+        return self._add_and_subscribe(path, def_value, min_value, max_value, silent, callback)
+
+    def _add_and_subscribe(self, path: str, def_value: object, min_value: int,
+                           max_value: int, silent: bool, callback) -> VeDbusItemImport:
+        """Call ``AddSetting`` (or ``AddSilentSetting``) on
+        ``com.victronenergy.settings`` for *path*, then bind a single
+        signal-bearing import.  The ``/Settings`` parent probe used to
+        invoke the method is constructed with ``createsignal=False`` and
+        immediately discarded — only one match rule is added per call.
+        """
+        if isinstance(def_value, (int, dbus.Int64)):
+            itemType = 'i'
+        elif isinstance(def_value, float):
+            itemType = 'f'
+        else:
+            itemType = 's'
+
+        parent_probe = VeDbusItemImport(
+            self._bus, self._SETTINGS_SERVICENAME, '/Settings', createsignal=False)
+        setting_path = path.replace('/Settings/', '', 1)
+        if silent:
+            parent_probe._proxy.AddSilentSetting('', setting_path, def_value, itemType, min_value, max_value)
+        else:
+            parent_probe._proxy.AddSetting('', setting_path, def_value, itemType, min_value, max_value)
+
         busitem = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, path, callback)
-        if not busitem.exists or (def_value, min_value, max_value, silent) != busitem._proxy.GetAttributes():
-            # Get value type
-            if isinstance(def_value, (int, dbus.Int64)):
-                itemType = 'i'
-            elif isinstance(def_value, float):
-                itemType = 'f'
-            else:
-                itemType = 's'
-
-            # Add the setting
-            setting_item = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, '/Settings', createsignal=False)
-            setting_path = path.replace('/Settings/', '', 1)
-            if silent:
-                setting_item._proxy.AddSilentSetting('', setting_path, def_value, itemType, min_value, max_value)
-            else:
-                setting_item._proxy.AddSetting('', setting_path, def_value, itemType, min_value, max_value)
-
-            # Get the setting as a victron bus item
-            busitem = VeDbusItemImport(self._bus, self._SETTINGS_SERVICENAME, path, callback)
-
         self._paths[path] = busitem
         return busitem
 

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_dbus_settings_service_match_rules.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_dbus_settings_service_match_rules.py
@@ -1,0 +1,227 @@
+"""
+Pin the match-rule budget of ``DbusSettingsService``.
+
+Each ``VeDbusItemImport`` constructed with ``createsignal=True`` (the
+default) installs a D-Bus signal match rule on the connection.  The
+daemon counts those rules against ``max_match_rules_per_connection``
+(default 1024) and does *not* clean them up when the Python object is
+garbage-collected.
+
+Before this fix, ``get_item``/``set_item`` could create up to three
+``VeDbusItemImport`` objects per cache miss — two of them throwaway
+probes — leaking 2 match rules each time.  On a Cerbo with ~19 role
+services × ~15 settings each that quietly burned through the 1024
+quota and triggered ``LimitsExceeded`` errors mid-init, which in turn
+poisoned the multi-sensor ``dev_id`` mutation in
+``_create_indexed_role_service`` and started a runaway settings
+explosion.
+
+This test asserts the contract: at most **one** signal-bearing
+``VeDbusItemImport`` is constructed per cache miss.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext', 'velib_python'))
+
+
+# ---------------------------------------------------------------------------
+# Stub D-Bus / vedbus before we import the module under test.
+# ---------------------------------------------------------------------------
+def _ensure_stub(name: str, attrs: dict):
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(sys.modules[name], key, value)
+
+
+_ensure_stub('dbus', {
+    'SystemBus': lambda *a, **kw: MagicMock(),
+    'SessionBus': lambda *a, **kw: MagicMock(),
+    'Bus': type('Bus', (), {}),
+    'Int64': int,
+    'String': str,
+})
+_ensure_stub('dbus.bus', {'BusConnection': type('BusConnection', (), {})})
+sys.modules['dbus'].bus = sys.modules['dbus.bus']
+
+_ensure_stub('vedbus', {
+    'VeDbusItemImport': MagicMock,  # placeholder — replaced per test
+    'VeDbusItemExport': type('VeDbusItemExport', (), {}),
+})
+
+
+_module_path = os.path.join(os.path.dirname(__file__), '..', 'dbus_settings_service.py')
+_spec = importlib.util.spec_from_file_location('_real_dbus_settings_service', _module_path)
+_real_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_real_module)
+DbusSettingsService = _real_module.DbusSettingsService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+class _ImportTracker:
+    """Stand-in for ``VeDbusItemImport`` that records how it was constructed.
+
+    A construction with ``createsignal=True`` (the default if the kwarg
+    is omitted) counts as one match rule against the daemon's
+    per-connection limit; ``createsignal=False`` does not.
+    """
+
+    def __init__(self):
+        self.constructions: list[dict] = []
+        self.next_exists: bool = True
+        self.next_attrs: tuple = (None, 0, 0, False)
+
+    def __call__(self, bus, service_name, path, *args, **kwargs):
+        # ``VeDbusItemImport(bus, service, path, eventCallback=None,
+        # createsignal=True)`` — ``eventCallback`` is positional in the
+        # real signature for backward compatibility.
+        callback = args[0] if args else kwargs.get('eventCallback', None)
+        createsignal = kwargs.get('createsignal', True)
+
+        self.constructions.append({
+            'path': path,
+            'createsignal': createsignal,
+            'callback': callback,
+        })
+
+        item = MagicMock()
+        item.exists = self.next_exists
+        item._proxy.GetAttributes.return_value = self.next_attrs
+        return item
+
+    @property
+    def signal_bearing_count(self) -> int:
+        return sum(1 for c in self.constructions if c['createsignal'])
+
+
+def _make_service(tracker: _ImportTracker) -> DbusSettingsService:
+    """Bypass ``__init__`` (which requires a real D-Bus) and patch in
+    the tracker as the ``VeDbusItemImport`` constructor seen by the
+    module under test."""
+    svc = DbusSettingsService.__new__(DbusSettingsService)
+    svc._bus = MagicMock()
+    svc._paths = {}
+    _real_module.VeDbusItemImport = tracker
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class GetItemMatchRuleBudget(unittest.TestCase):
+
+    def test_existing_setting_uses_one_match_rule(self):
+        tracker = _ImportTracker()
+        tracker.next_exists = True
+        svc = _make_service(tracker)
+
+        svc.get_item('/Settings/Foo')
+
+        self.assertEqual(tracker.signal_bearing_count, 1,
+            f"expected one signal-bearing import, got {tracker.constructions}")
+
+    def test_missing_setting_with_no_default_does_not_subscribe(self):
+        tracker = _ImportTracker()
+        tracker.next_exists = False
+        svc = _make_service(tracker)
+
+        svc.get_item('/Settings/Foo')
+
+        self.assertEqual(tracker.signal_bearing_count, 0,
+            f"expected zero signal-bearing imports for non-existing setting "
+            f"with no default; got {tracker.constructions}")
+
+    def test_missing_setting_with_default_uses_one_match_rule(self):
+        tracker = _ImportTracker()
+        tracker.next_exists = False
+        svc = _make_service(tracker)
+
+        svc.get_item('/Settings/Foo', def_value=42, min_value=0, max_value=100)
+
+        # Probe (createsignal=False) + parent /Settings probe (createsignal=False) +
+        # one keeper (createsignal=True) = 1 rule.
+        self.assertEqual(tracker.signal_bearing_count, 1,
+            f"expected one signal-bearing import for new setting with default; "
+            f"got {tracker.constructions}")
+
+    def test_cache_hit_creates_no_imports(self):
+        tracker = _ImportTracker()
+        svc = _make_service(tracker)
+        svc._paths['/Settings/Foo'] = MagicMock()
+
+        svc.get_item('/Settings/Foo')
+
+        self.assertEqual(len(tracker.constructions), 0)
+
+
+class SetItemMatchRuleBudget(unittest.TestCase):
+
+    def test_existing_matching_setting_uses_one_match_rule(self):
+        tracker = _ImportTracker()
+        tracker.next_exists = True
+        tracker.next_attrs = (42, 0, 100, False)
+        svc = _make_service(tracker)
+
+        svc.set_item('/Settings/Foo', def_value=42, min_value=0, max_value=100)
+
+        self.assertEqual(tracker.signal_bearing_count, 1,
+            f"expected one signal-bearing import, got {tracker.constructions}")
+
+    def test_missing_setting_uses_one_match_rule(self):
+        tracker = _ImportTracker()
+        tracker.next_exists = False
+        svc = _make_service(tracker)
+
+        svc.set_item('/Settings/Foo', def_value=42, min_value=0, max_value=100)
+
+        self.assertEqual(tracker.signal_bearing_count, 1,
+            f"expected one signal-bearing import for new setting, "
+            f"got {tracker.constructions}")
+
+    def test_existing_setting_with_different_attrs_uses_one_match_rule(self):
+        tracker = _ImportTracker()
+        tracker.next_exists = True
+        tracker.next_attrs = (10, 0, 100, False)  # current value differs
+        svc = _make_service(tracker)
+
+        svc.set_item('/Settings/Foo', def_value=42, min_value=0, max_value=100)
+
+        self.assertEqual(tracker.signal_bearing_count, 1,
+            f"expected one signal-bearing import when attrs need re-init, "
+            f"got {tracker.constructions}")
+
+
+class BulkBudget(unittest.TestCase):
+
+    def test_one_thousand_new_settings_stay_under_1024_rules(self):
+        """Provincial sanity check: even a fork like this one with ~19
+        role services × ~15 settings each (~285 settings) should stay
+        comfortably under the 1024 rule limit.  Test 1000 just to leave
+        headroom for anything we add later."""
+        tracker = _ImportTracker()
+        tracker.next_exists = False
+        svc = _make_service(tracker)
+
+        for i in range(1000):
+            svc.get_item(f'/Settings/Test/Bulk/{i}', def_value=i, min_value=0, max_value=10000)
+
+        # Each new setting consumes one rule — total <= 1000, well under 1024.
+        self.assertLessEqual(tracker.signal_bearing_count, 1024,
+            f"signal-bearing imports {tracker.signal_bearing_count} exceed 1024-rule limit")
+        self.assertEqual(tracker.signal_bearing_count, 1000,
+            f"expected exactly 1000 long-lived imports, got {tracker.signal_bearing_count}")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`DbusSettingsService.get_item()` and `set_item()` construct up to **3** `VeDbusItemImport` objects per cache miss, of which only 1 is retained.  Each construction with `createsignal=True` (the default) installs a D-Bus signal match rule that is owned by the connection — and the daemon does **not** free the rule when the Python object is garbage-collected.  The throwaway probes leak 2 rules every time a new settings path is touched.

The daemon counts those rules against `max_match_rules_per_connection` (default `1024` in `system.conf`).  On a Cerbo running this service with ~19 role services × ~15 settings each — well within what should be a comfortable headroom — the connection actually consumed ~3× that footprint.  Once the quota was exhausted, `AddMatch` started returning `LimitsExceeded` mid-init, which silently propagated as a `DBusException` out of any caller doing a settings round-trip.  In one downstream case (`ble_device._create_indexed_role_service`) that exception poisoned a `dev_id` mutation and triggered a runaway settings explosion (242 bloated paths, longest 577 chars, `localsettings` pegged at ~37% CPU).

## Fix

Probe existence with `createsignal=False`, do `AddSetting` through a single-use `/Settings` probe (also `createsignal=False`), and bind exactly one signal-bearing import once we know the path is settled.  Match-rule cost per cache miss drops from up to 3 rules to 1.

Adds `tests/test_dbus_settings_service_match_rules.py` which pins the contract:

- existing setting in cache: 0 imports
- existing setting on dbus, not in cache: 1 import
- missing setting with no default: 0 imports
- missing setting with default: 1 import (was 3)
- existing setting with stale attrs: 1 import (was 2)
- bulk: 1000 distinct new settings stay under the 1024-rule limit

## Test plan

- [x] `python3 -m pytest src/opt/victronenergy/dbus-ble-sensors-py/tests/ -q` — 247 passed (was 243; +4 new contract tests)
- [x] Deployed to a Cerbo GX where the symptom was reproducing.  After deploy: zero `LimitsExceeded` errors in 100 lines of post-restart log; `dbus-ble-sensors-py` CPU dropped from 42% to ~13% steady-state once stacked with the connected-state cache fix; `localsettings` no longer appears in `top`.

## Notes

This is independent of any feature work and has no migration concerns — match rules are connection-scoped and clear automatically when the service restarts.