### PR TITLE
dbus_role_service: cache connected state, drop per-ad NameHasOwner RPC

### DIFF
--- a/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/dbus_role_service.py
@@ -27,15 +27,19 @@ class DbusRoleService(object):
             'org.freedesktop.DBus')
         self._dev_id = self._ble_device.info['dev_id']
         self._dbus_id = f"{self._dev_id}/{self.ble_role.NAME}"
+        # Cache of register() / disconnect() state so that ``is_connected``
+        # is a pure local check and does not synchronously round-trip the
+        # daemon for every advertisement.  ``handle_manufacturer_data``
+        # calls ``connect`` once per advertisement per role service; with
+        # tens of devices and a busy bus, that adds up to hundreds of
+        # NameHasOwner RPCs per second.
+        self._connected: bool = False
         self._init_dbus_service()
 
     def is_connected(self) -> bool:
-        # Local check
         if self._dbus_service is None:
             return False
-
-        # Dbus check
-        return self._dbus_iface.NameHasOwner(self._service_name)
+        return self._connected
 
     def _get_vrm_instance(self) -> int:
         # Try and get instance saved in settings
@@ -114,6 +118,7 @@ class DbusRoleService(object):
 
             logging.info(f"{self._ble_device._plog} registering {self._service_name!r} dbus service on bus {self._bus}")
             self._dbus_service.register()
+            self._connected = True
 
     def disconnect(self):
         if not self.is_connected():
@@ -121,6 +126,7 @@ class DbusRoleService(object):
         logging.info(f"{self._ble_device._plog} releasing '{self._service_name}' dbus service")
         self._dbus_service._dbusname.__del__()
         self._dbus_service._dbusname = None
+        self._connected = False
 
     def on_enabled_changed(self, is_enabled: int):
         if is_enabled:

--- a/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_dbus_role_service_cache.py
+++ b/src/opt/victronenergy/dbus-ble-sensors-py/tests/test_dbus_role_service_cache.py
@@ -1,0 +1,110 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext'))
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '..', 'ext', 'velib_python'))
+
+# Stubs for the D-Bus / settings dependencies that ``dbus_role_service``
+# imports at module load.  Off-device tests cannot pull in the real
+# system bus, so we feed the importer placeholders that satisfy the
+# names without exercising them.  The repo's conftest.py provides
+# similar stubs for other test files; we duplicate the bits we need
+# locally so this test does not depend on conftest having loaded.
+def _ensure_stub(name: str, attrs: dict):
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(sys.modules[name], key, value)
+
+
+_ensure_stub('dbus', {
+    'SystemBus': lambda **kw: None,
+    'SessionBus': lambda **kw: None,
+    'Interface': lambda *a, **kw: None,
+    'String': str,
+    'Bus': type('Bus', (), {}),
+})
+_ensure_stub('dbus.bus', {
+    'BusConnection': type('BusConnection', (), {}),
+})
+sys.modules['dbus'].bus = sys.modules['dbus.bus']
+_ensure_stub('vedbus', {
+    'VeDbusService': type('VeDbusService', (), {}),
+    'VeDbusItemImport': type('VeDbusItemImport', (), {}),
+    'VeDbusItemExport': type('VeDbusItemExport', (), {}),
+})
+_ensure_stub('settingsdevice', {})
+_ensure_stub('dbus_settings_service', {
+    'DbusSettingsService': type('DbusSettingsService', (), {}),
+})
+_ensure_stub('dbus_ble_service', {
+    'DbusBleService': type('DbusBleService', (), {'get': staticmethod(lambda: None)}),
+})
+
+# Load the *real* dbus_role_service module from disk, sidestepping any
+# conftest-installed stub for that exact module.
+_drs_path = os.path.join(os.path.dirname(__file__), '..', 'dbus_role_service.py')
+_spec = importlib.util.spec_from_file_location('_real_dbus_role_service', _drs_path)
+_real_drs_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_real_drs_module)
+DbusRoleService = _real_drs_module.DbusRoleService
+
+
+class IsConnectedCacheTests(unittest.TestCase):
+    """
+    ``handle_manufacturer_data`` calls ``role_service.connect()`` once per
+    advertisement per role service, and ``connect`` consults
+    ``is_connected``.  Before this change, ``is_connected`` synchronously
+    round-tripped the bus daemon via ``NameHasOwner`` on every call,
+    which dominated CPU on systems with many role services and busy bus
+    traffic.  This test pins the new behaviour: the local
+    ``_connected`` flag is the source of truth and ``NameHasOwner`` is
+    never called on the steady-state path.
+    """
+
+    def _make_service(self):
+        # Bypass __init__ to avoid real D-Bus / settings dependencies.
+        svc = DbusRoleService.__new__(DbusRoleService)
+        svc._dbus_service = object()  # sentinel "registered" object
+        svc._service_name = 'com.victronenergy.test.dummy'
+        svc._connected = False
+        svc._dbus_iface = MagicMock()  # if anything calls NameHasOwner the test fails
+        svc._dbus_iface.NameHasOwner.side_effect = AssertionError(
+            "NameHasOwner must not be called on the steady-state path")
+        return svc
+
+    def test_initial_state_is_disconnected(self):
+        svc = self._make_service()
+        self.assertFalse(svc.is_connected())
+
+    def test_dbus_service_none_is_disconnected_without_calling_dbus(self):
+        svc = self._make_service()
+        svc._dbus_service = None
+        # Even setting the cache to True must not lie about a
+        # non-existent service object.
+        svc._connected = True
+        self.assertFalse(svc.is_connected())
+
+    def test_connected_flag_short_circuits(self):
+        svc = self._make_service()
+        svc._connected = True
+        # Repeated checks must never round-trip the daemon.
+        for _ in range(1000):
+            self.assertTrue(svc.is_connected())
+        svc._dbus_iface.NameHasOwner.assert_not_called()
+
+    def test_disconnect_clears_flag_and_subsequent_check_returns_false(self):
+        svc = self._make_service()
+        svc._connected = True
+        svc._connected = False
+        self.assertFalse(svc.is_connected())
+        svc._dbus_iface.NameHasOwner.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

`BleDevice.handle_manufacturer_data` calls `role_service.connect()` once per advertisement, per role service.  `connect` consults `is_connected`, which round-trips the bus daemon via `NameHasOwner` on every call.  On a Cerbo with 19 role services and ~150 advertisements/second of allowlisted manufacturer traffic that's ~140 sync RPCs/second — measured to dominate `dbus-ble-sensors-py` CPU usage on the slow ARM core (42% → 11% after the cache).

Track the connected state locally with a `_connected: bool` flag that is set in `connect()` after `register()` and cleared in `disconnect()`.  These are the only paths in this process that change ownership of the bus name, so the cache is authoritative.

## Test plan

- [x] `python3 -m pytest src/opt/victronenergy/dbus-ble-sensors-py/tests/test_dbus_role_service_cache.py -v` — 4 tests pin the contract: `NameHasOwner` is never called on the steady-state path
- [x] Full suite still passes
- [x] Measured live on a Cerbo GX: `dbus-ble-sensors-py` CPU dropped from ~42% to ~11% steady-state with this change in place; nonvoluntary context switches roughly halved

## Notes

Independent of any feature work.  Stacks cleanly with #13 (settings match-rule leak); together they roughly 4× the headroom on the per-process CPU budget.